### PR TITLE
Improve workbook sheet detection and fallback parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3863,7 +3863,7 @@ async function parseExcel(buf){
       dense:true,
       range:sampleRange
     });
-    if(!sample || sample.length<3) continue;
+    if(!sample || !sample.length) continue;
     const headerRowIndex=detectHeaderRowIndex(sample);
     const headers=Array.isArray(sample[headerRowIndex])?sample[headerRowIndex]:[];
     const normalizedHeaders=headers.map(value=>String(value??'').trim());
@@ -3878,14 +3878,57 @@ async function parseExcel(buf){
       bestTextCount=textCount;
     }
   }
-  if(!best) throw new Error('No usable sheet found');
-  const ws=wb.Sheets[best];
-  const sheetData=XLSX.utils.sheet_to_json(ws,{
-    header:1,
-    raw:true,
-    defval:null,
-    dense:true
-  });
+  let sheetName=best;
+  let sheetData=null;
+  if(!sheetName){
+    for(const name of wb.SheetNames){
+      const ws=wb.Sheets[name];
+      if(!ws) continue;
+      const data=XLSX.utils.sheet_to_json(ws,{
+        header:1,
+        raw:true,
+        defval:null,
+        dense:true
+      });
+      if(Array.isArray(data) && data.length){
+        sheetName=name;
+        sheetData=data;
+        break;
+      }
+    }
+  }
+  if(!sheetName) throw new Error('No usable sheet found');
+  let ws=wb.Sheets[sheetName];
+  if(!sheetData){
+    sheetData=XLSX.utils.sheet_to_json(ws,{
+      header:1,
+      raw:true,
+      defval:null,
+      dense:true
+    });
+  }
+  if(!Array.isArray(sheetData) || sheetData.length<3){
+    for(const name of wb.SheetNames){
+      if(name===sheetName) continue;
+      const alt=wb.Sheets[name];
+      if(!alt) continue;
+      const data=XLSX.utils.sheet_to_json(alt,{
+        header:1,
+        raw:true,
+        defval:null,
+        dense:true
+      });
+      if(Array.isArray(data) && data.length>=3){
+        sheetName=name;
+        ws=alt;
+        sheetData=data;
+        break;
+      }
+    }
+  }
+  if(!Array.isArray(sheetData) || sheetData.length<3){
+    throw new Error('No usable sheet found');
+  }
   const headerRowIndex=detectHeaderRowIndex(sheetData);
   await buildStateFromSheetData(sheetData,{headerRowIndex});
 }


### PR DESCRIPTION
### Motivation
- Parsing large or irregular workbooks can fail when the initial sample window doesn't include a usable header row. 
- The previous logic required a sampled sheet to have at least 3 rows which caused some valid sheets to be skipped.
- Provide a more robust fallback to select a usable sheet when automatic header detection doesn't pick a clear winner.

### Description
- Relaxed the sample check in `parseExcel` from `sample.length<3` to `!sample.length` so sheets with small samples are still considered. 
- Added a fallback loop to pick the first non-empty sheet when no `best` sheet is detected, by reading full sheet data with `XLSX.utils.sheet_to_json`.
- If the chosen sheet has fewer than 3 rows the code now iterates remaining sheets to find one with `>=3` rows before throwing `No usable sheet found`.
- Kept existing `detectHeaderRowIndex` and `buildStateFromSheetData` usage and preserved the original error message when no usable data is available.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946672ca0e48329967a221073f6d846)