### PR TITLE
Add fallback parsing for large workbooks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4080,8 +4080,16 @@ async function parseExcel(buf){
           dense:true,
           range:fallbackSampleRange
         })) + (fallbackSampleRange.s.r || 0);
-      await buildStateFromWorksheet(ws,{headerRowIndex});
-      return;
+      try{
+        await buildStateFromWorksheet(ws,{headerRowIndex});
+        return;
+      }catch(err){
+        const message=String(err?.message||err);
+        if(!message.includes('No usable sheet found')){
+          throw err;
+        }
+        console.warn('Large sheet parse failed; falling back to full sheet parse.', err);
+      }
     }
     sheetData=XLSX.utils.sheet_to_json(ws,{
       header:1,


### PR DESCRIPTION
### Motivation

- Loading very large workbook files (e.g. the `Products Search Term.xlsx`) could fail during the optimized chunked/worksheet parsing path and leave the UI without data.  
- The previous fast-path `buildStateFromWorksheet` call could throw a `No usable sheet found` error for some large sheets and prevent a secondary parse attempt.  
- Restore robustness by falling back to a full-sheet parse when the optimized path reports an unrecoverable sheet detection failure.  

### Description

- Wrapped the `buildStateFromWorksheet(ws,{headerRowIndex})` call inside a `try/catch` in `parseExcel` (file `index.html`) to catch failures from the large-sheet optimized path.  
- If the thrown error message contains `No usable sheet found` the code now logs a warning via `console.warn` and falls back to parsing the full sheet with `XLSX.utils.sheet_to_json`.  
- Any other errors are re-thrown so genuine failures are still surfaced.  
- This preserves the large-sheet optimized path while providing a safe fallback for datasets that previously caused the UI to abort loading.  

### Testing

- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1f5dcedc8329903ad7a4d56ca7b3)