### PR TITLE
Add project-local FastAPI backend and fetch workbook via API for Products Search Term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/.env

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,3 @@
+# Example configuration for Products Search Term backend
+# Use an absolute path to the Excel file on this machine.
+EXCEL_FILE_PATH=/absolute/path/to/Products Search Term.xlsx

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+
+from dotenv import dotenv_values
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+
+
+BASE_DIR = Path(__file__).resolve().parent
+ENV_PATH = BASE_DIR / ".env"
+
+
+@lru_cache(maxsize=1)
+def load_config() -> Dict[str, Path]:
+    values = dotenv_values(ENV_PATH)
+    excel_raw = (values.get("EXCEL_FILE_PATH") or "").strip()
+    if not excel_raw:
+        raise RuntimeError("EXCEL_FILE_PATH is missing in backend/.env")
+    excel_path = Path(excel_raw).expanduser().resolve()
+    return {"excel_path": excel_path}
+
+
+app = FastAPI(title="Products Search Term API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/api/health")
+def healthcheck() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/api/workbook")
+def get_workbook() -> FileResponse:
+    try:
+        config = load_config()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    workbook_path = config["excel_path"]
+    if not workbook_path.exists() or not workbook_path.is_file():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Excel file not found at {workbook_path}",
+        )
+
+    return FileResponse(
+        workbook_path,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename=workbook_path.name,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.6
+python-dotenv==1.0.1
+uvicorn[standard]==0.30.6

--- a/index.html
+++ b/index.html
@@ -2634,9 +2634,12 @@ let filterBackfillToken=0;
 const pivotFilterPopupState={slot:'', options:[], filtered:[], dimension:null, button:null, displayName:'', search:'', mode:'dimension', dateTab:'months'};
 const DEFAULT_PREPROCESSED_DATA=[];
 const DEFAULT_WORKBOOKS=[
-  'Products Search Term.xlsx',
-  'Products Campaign.xlsx'
+  'Products Search Term.xlsx'
 ];
+const API_BASE_URL=(typeof window!=='undefined' && window.PRODUCTS_SEARCH_TERM_API_BASE)
+  ? String(window.PRODUCTS_SEARCH_TERM_API_BASE).replace(/\/+$/,'')
+  : 'http://localhost:8000';
+const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
 const LARGE_SHEET_ROW_THRESHOLD=100000;
 const LARGE_SHEET_CHUNK_SIZE=100000;
 const ASIN_SKU_WORKBOOK='ASINwise SKU.xlsx';
@@ -3786,12 +3789,13 @@ async function loadWorkbookBuffer(buf, options={}){
 }
 
 async function fetchArrayBufferFromUrl(file){
-  let targetUrl;
-  try{
-    targetUrl=new URL(file, document.baseURI).href;
+  const targetUrl=(()=>{ try{
+    const url=new URL(WORKBOOK_API_ENDPOINT);
+    if(file) url.searchParams.set('name', file);
+    return url.toString();
   }catch(_){
-    targetUrl=encodeURI(file);
-  }
+    return WORKBOOK_API_ENDPOINT;
+  }})();
   const response=await fetch(targetUrl,{cache:'no-store'});
   if(!response.ok && response.status!==0){
     const status=response.status||'';


### PR DESCRIPTION
### Motivation
- Serve the large Excel workbook from a backend on the developer machine to avoid client-side memory/timeout issues when loading big files.
- Keep all configuration scoped to the single project by using a project-local `backend/.env` file and avoid any system-wide environment variables.
- Modify only the dashboard's frontend data-loading logic so the UI remains unchanged while switching to an API-backed data source.
- Limit the change surface to the single workbook used by the dashboard (`Products Search Term.xlsx`).

### Description
- Add a lightweight FastAPI backend in `backend/main.py` that reads `EXCEL_FILE_PATH` from `backend/.env` (via `dotenv_values`) and exposes `GET /api/health` and `GET /api/workbook` to stream the configured Excel file.
- Add `backend/requirements.txt` with `fastapi`, `python-dotenv`, and `uvicorn`, and add an example `backend/.env` with `EXCEL_FILE_PATH` and add `backend/.env` to `.gitignore` to keep configuration project-local.
- Update the frontend `index.html` to restrict `DEFAULT_WORKBOOKS` to `Products Search Term.xlsx`, introduce `API_BASE_URL` / `WORKBOOK_API_ENDPOINT`, and change `fetchArrayBufferFromUrl` to fetch the workbook from the new backend API instead of loading the file directly from the Pages host.
- Ensure backend config is cached with `lru_cache` and that CORS for the API permits the dashboard to fetch the workbook via `GET`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535aa7e7c88320b6c8fb0ebb37bd30)