### PR TITLE
Add Products Campaign workbook and resilient workbook fetching fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2634,11 +2634,13 @@ let filterBackfillToken=0;
 const pivotFilterPopupState={slot:'', options:[], filtered:[], dimension:null, button:null, displayName:'', search:'', mode:'dimension', dateTab:'months'};
 const DEFAULT_PREPROCESSED_DATA=[];
 const DEFAULT_WORKBOOKS=[
-  'Products Search Term.xlsx'
+  'Products Search Term.xlsx',
+  'Products Campaign.xlsx'
 ];
 const API_BASE_URL=(typeof window!=='undefined' && window.PRODUCTS_SEARCH_TERM_API_BASE)
   ? String(window.PRODUCTS_SEARCH_TERM_API_BASE).replace(/\/+$/,'')
   : 'http://localhost:8000';
+const HAS_EXPLICIT_API_BASE=typeof window!=='undefined' && !!window.PRODUCTS_SEARCH_TERM_API_BASE;
 const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
 const LARGE_SHEET_ROW_THRESHOLD=100000;
 const LARGE_SHEET_CHUNK_SIZE=100000;
@@ -3789,21 +3791,44 @@ async function loadWorkbookBuffer(buf, options={}){
 }
 
 async function fetchArrayBufferFromUrl(file){
-  const targetUrl=(()=>{ try{
+  const apiUrl=(()=>{ try{
     const url=new URL(WORKBOOK_API_ENDPOINT);
     if(file) url.searchParams.set('name', file);
     return url.toString();
   }catch(_){
     return WORKBOOK_API_ENDPOINT;
   }})();
-  const response=await fetch(targetUrl,{cache:'no-store'});
-  if(!response.ok && response.status!==0){
-    const status=response.status||'';
-    const statusText=response.statusText||'';
-    const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
-    throw new Error(detail||'Unable to fetch dataset');
+  let apiError=null;
+  if(apiUrl){
+    try{
+      const response=await fetch(apiUrl,{cache:'no-store'});
+      if(response.ok || response.status===0) return response.arrayBuffer();
+      const status=response.status||'';
+      const statusText=response.statusText||'';
+      const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
+      apiError=new Error(detail||'Unable to fetch dataset');
+    }catch(err){
+      apiError=err;
+    }
   }
-  return response.arrayBuffer();
+  if(!file){
+    throw apiError || new Error('Unable to fetch dataset');
+  }
+  if(HAS_EXPLICIT_API_BASE){
+    throw apiError || new Error('Unable to fetch dataset');
+  }
+  let directUrl;
+  try{
+    directUrl=new URL(file, document.baseURI).href;
+  }catch(_){
+    directUrl=encodeURI(file);
+  }
+  const response=await fetch(directUrl,{cache:'no-store'});
+  if(response.ok || response.status===0) return response.arrayBuffer();
+  const status=response.status||'';
+  const statusText=response.statusText||'';
+  const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
+  throw new Error(detail||'Unable to fetch dataset');
 }
 
 async function fetchJsonFromUrl(file){


### PR DESCRIPTION
### Motivation

- Provide the app with the missing built-in workbook option for campaign data by including `Products Campaign.xlsx` in the defaults.
- Improve robustness when loading workbook files from environments without the API proxy by falling back to direct file fetches.
- Avoid silently failing dataset loads when the configured API base is unavailable while preserving strictness when an explicit API base is set.

### Description

- Added `Products Campaign.xlsx` to `DEFAULT_WORKBOOKS` so it appears in built-in dataset options.
- Introduced `HAS_EXPLICIT_API_BASE` to detect when `window.PRODUCTS_SEARCH_TERM_API_BASE` is explicitly configured.
- Reworked `fetchArrayBufferFromUrl` to attempt the API endpoint first and capture any API error, then fall back to fetching the file directly from the app origin when no explicit API base is set, and otherwise rethrow the API error.
- Kept existing behavior for the workbook API endpoint and preserved error messages for failed HTTP responses.

### Testing

- Started a local static server (`python -m http.server`) and used Playwright to load `index.html` and capture a screenshot, which completed successfully.
- The static load sequence performed HTTP requests and returned `200` for `ASINwise SKU.xlsx`, indicating static file fetch worked.
- Verified the app renders dataset options including the new `Products Campaign.xlsx` in the built-in list via the generated screenshot.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535e0cf588832087a60987374a0ba0)