### PR TITLE
Improve large workbook sheet selection and memory‑efficient parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2644,6 +2644,9 @@ const HAS_EXPLICIT_API_BASE=typeof window!=='undefined' && !!window.PRODUCTS_SEA
 const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
 const LARGE_SHEET_ROW_THRESHOLD=100000;
 const LARGE_SHEET_CHUNK_SIZE=100000;
+const WORKBOOK_SHEET_PREFERENCES={
+  'products search term.xlsx':['Sheet1','Products Search Term','Search Term']
+};
 const ASIN_SKU_WORKBOOK='ASINwise SKU.xlsx';
 const ADVERTISED_PRODUCTS_WORKBOOK=ASIN_SKU_WORKBOOK;
 let asinSkuPromise=null;
@@ -3773,7 +3776,7 @@ async function handleLocalFile(e){
   }
 }
 async function loadWorkbookBuffer(buf, options={}){
-  await parseExcel(buf);
+  await parseExcel(buf,{dataset:options?.dataset||null});
   if(options?.dataset){
     setActiveDataset(options.dataset);
   }else if(options){
@@ -4033,11 +4036,34 @@ async function buildStateFromWorksheet(ws, options={}){
   }
 }
 
-async function parseExcel(buf){
-  const wb = XLSX.read(buf, { type:'array', cellDates:true, cellNF:true, cellText:false });
+function resolvePreferredSheetName(wb, dataset){
+  if(!wb || !Array.isArray(wb.SheetNames) || !wb.SheetNames.length) return null;
+  const sheetNames=wb.SheetNames;
+  const fileRaw=dataset?.file?String(dataset.file):'';
+  const labelRaw=dataset?.label?String(dataset.label):'';
+  const fileName=(fileRaw.split(/[\\/]/).pop()||'').toLowerCase();
+  const baseName=fileName.replace(/\.[^.]+$/,'');
+  const candidates=[];
+  const preferredList=WORKBOOK_SHEET_PREFERENCES[fileName];
+  if(Array.isArray(preferredList)) candidates.push(...preferredList);
+  if(baseName) candidates.push(baseName);
+  if(labelRaw) candidates.push(labelRaw);
+  const normalizedCandidates=candidates.map(c=>String(c).trim().toLowerCase()).filter(Boolean);
+  if(!normalizedCandidates.length) return null;
+  for(const name of sheetNames){
+    const normalizedName=String(name).trim().toLowerCase();
+    if(normalizedCandidates.includes(normalizedName)) return name;
+  }
+  return null;
+}
+
+async function parseExcel(buf, options={}){
+  const wb = XLSX.read(buf, { type:'array', cellDates:true, cellNF:false, cellText:false, dense:true });
+  const preferredSheet=resolvePreferredSheetName(wb, options?.dataset||null);
   let best=null,score=-1,bestTextCount=-1;
   const headerRowCandidates=new Map();
-  for(const name of wb.SheetNames){
+  const sheetNamesToScan=preferredSheet?[preferredSheet]:wb.SheetNames;
+  for(const name of sheetNamesToScan){
     const ws=wb.Sheets[name];
     if(!ws) continue;
     const ref=ws['!ref'];
@@ -4071,7 +4097,7 @@ async function parseExcel(buf){
       bestTextCount=textCount;
     }
   }
-  let sheetName=best;
+  let sheetName=preferredSheet || best;
   let sheetData=null;
   if(!sheetName){
     for(const name of wb.SheetNames){


### PR DESCRIPTION
### Motivation
- Fix failures loading the very large `Products Search Term.xlsx` that raised `No usable sheet found` when auto-detection scanned the whole workbook.
- Large sheet auto-parsing was expensive and could hit memory/time limits for big files.
- Ensure the dashboard behavior and file layout remain unchanged while making workbook loading safer and more deterministic.
- Prefer the intended worksheet explicitly so the correct data is selected even for huge files.

### Description
- Add `WORKBOOK_SHEET_PREFERENCES` and a `resolvePreferredSheetName` helper to map `Products Search Term.xlsx` to likely sheet names like `Sheet1`, `Products Search Term`, and `Search Term`.
- Pass dataset metadata into `parseExcel` by changing `loadWorkbookBuffer` to call `parseExcel(buf, {dataset: options?.dataset||null})` so sheet selection can use the file/label.
- Limit sheet scanning to the preferred sheet when available and fall back to the existing detection logic otherwise, reducing unnecessary reads of other sheets.
- Use more memory-efficient `XLSX.read` options (`cellNF:false`, `cellText:false`, `dense:true`) and avoid broad full-workbook parsing for very large sheets.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2ee4665c83209cbca79737401cae)