### PR TITLE
Fallback to workbook when preprocessed dataset load fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -3863,8 +3863,12 @@ async function loadWorkbookDatasetFromUrl(file,label){
       file,
       label:label || formatDatasetLabelFromFile(file)
     };
-    await loadPreprocessedDatasetFromUrl(preprocessedFile,dataset.label,{dataset});
-    return dataset;
+    try{
+      await loadPreprocessedDatasetFromUrl(preprocessedFile,dataset.label,{dataset});
+      return dataset;
+    }catch(err){
+      console.warn(`Preprocessed dataset load failed (${preprocessedFile}); falling back to workbook.`, err);
+    }
   }
   const dataset={
     type:'workbook',


### PR DESCRIPTION
### Motivation
- Preprocessed JSON for a workbook can be missing or fail to load (e.g. 404 or malformed), causing dataset loading to fail.  
- The UI should recover by falling back to loading the original workbook file when the preprocessed payload is unavailable.  
- A warning should be logged to aid debugging when the fallback occurs.  

### Description
- Wrap the call to `loadPreprocessedDatasetFromUrl` inside `loadWorkbookDatasetFromUrl` with a `try/catch`.  
- On error, log a warning via `console.warn` that includes the preprocessed file name and the error, then continue to load the workbook.  
- Preserve the existing workbook-loading path (`fetchArrayBufferFromUrl` + `loadWorkbookBuffer`) and return the dataset as before.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3821fd248320bcdf08d163c60dea)