### PR TITLE
Add optional CSV export to local data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ GitHub. The dashboard will continue to read the same files at the same paths
 The script streams large Excel files safely with `openpyxl` (read-only mode),
 writes the preprocessed JSON into `preprocessed/`, then runs `git add`,
 `git commit`, and `git push` so GitHub Pages can pick up the updated data.
+If you also set `csv_output_path` for a workbook entry, the pipeline writes a
+CSV alongside the JSON and includes it in the git commit.
 
 Optional flags:
 - `--only products-search-term` (process just one dataset)

--- a/tools/local_pipeline.py
+++ b/tools/local_pipeline.py
@@ -8,6 +8,7 @@ preprocessed/ folder, and commits + pushes the changes to this repository.
 from __future__ import annotations
 
 import argparse
+import csv
 import datetime as dt
 import json
 import subprocess
@@ -109,6 +110,14 @@ def write_json_rows(
         fp.write("\n  ]\n}\n")
 
 
+def write_csv_rows(output_path: Path, rows: Iterable[List[object]]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as fp:
+        writer = csv.writer(fp)
+        for row in rows:
+            writer.writerow(["" if value is None else value for value in row])
+
+
 def iter_sheet_rows(
     excel_path: Path,
     sheet_name: str,
@@ -174,6 +183,7 @@ def process_workbooks(config: dict, only_names: List[str]) -> List[Path]:
         excel_path_raw = str(entry.get("excel_path", "")).strip()
         sheet_name = str(entry.get("sheet_name", "")).strip()
         output_path_raw = str(entry.get("output_path", "")).strip()
+        csv_output_path_raw = str(entry.get("csv_output_path", "")).strip()
         header_row_index = int(entry.get("header_row_index", 1))
         if not excel_path_raw:
             raise ValueError(f"Workbook entry '{name or output_path_raw}' is missing excel_path")
@@ -190,16 +200,26 @@ def process_workbooks(config: dict, only_names: List[str]) -> List[Path]:
         if not output_path.is_absolute():
             output_path = repo_root / output_path
 
-        rows = iter_sheet_rows(excel_path, sheet_name, header_row_index)
         write_json_rows(
             output_path=output_path,
-            rows=rows,
+            rows=iter_sheet_rows(excel_path, sheet_name, header_row_index),
             source=excel_path.name,
             sheet_name=sheet_name,
             header_row_index=header_row_index,
         )
         print(f"Wrote {output_path}")
         outputs.append(output_path)
+
+        if csv_output_path_raw:
+            csv_output_path = Path(csv_output_path_raw)
+            if not csv_output_path.is_absolute():
+                csv_output_path = repo_root / csv_output_path
+            write_csv_rows(
+                output_path=csv_output_path,
+                rows=iter_sheet_rows(excel_path, sheet_name, header_row_index),
+            )
+            print(f"Wrote {csv_output_path}")
+            outputs.append(csv_output_path)
 
     if only_names and not outputs:
         raise ValueError(f"No matching datasets found for --only {only_names}")

--- a/tools/local_pipeline_config.example.json
+++ b/tools/local_pipeline_config.example.json
@@ -6,6 +6,7 @@
       "excel_path": "C:/path/to/Products Search Term.xlsx",
       "sheet_name": "Products Search Term",
       "output_path": "preprocessed/Products Search Term.json",
+      "csv_output_path": "preprocessed/Products Search Term.csv",
       "header_row_index": 1
     },
     {
@@ -13,6 +14,7 @@
       "excel_path": "C:/path/to/Products Campaign.xlsx",
       "sheet_name": "Products Campaign",
       "output_path": "preprocessed/Products Campaign.json",
+      "csv_output_path": "preprocessed/Products Campaign.csv",
       "header_row_index": 1
     }
   ]


### PR DESCRIPTION
### Motivation
- Provide an alternate, smaller export format so the site can load preprocessed data when Excel workbooks are problematic or missing. 
- Keep dashboard visuals, charts, slicers, layout, and logic unchanged while fixing data-loading by producing CSV/JSON artifacts the site can consume.
- Make it simple to publish both JSON and CSV from the same local pipeline configuration so static hosting can pick up either format.

### Description
- Added a `write_csv_rows` helper and CSV support to `tools/local_pipeline.py` so the pipeline can write a CSV version of a worksheet alongside the existing JSON export via the existing row iterator (`iter_sheet_rows`).
- Config now accepts an optional `csv_output_path` per workbook in `tools/local_pipeline_config.example.json` to enable CSV output for that dataset.
- The pipeline appends generated CSV output paths to the list of produced outputs so they are included by the pipeline publishing step (no dashboard logic changed).
- Updated `README.md` to document the optional `csv_output_path` behavior.

### Testing
- No automated tests were run for this change.
- Verified the modified files: `tools/local_pipeline.py`, `tools/local_pipeline_config.example.json`, and `README.md` were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4270b5b483209c4281e73eac95f6)