### PR TITLE
Set Sheet1 as default for Products Search Term dataset

### DIFF
--- a/auto_update_dashboard.py
+++ b/auto_update_dashboard.py
@@ -23,7 +23,7 @@ from watchdog.observers import Observer
 # =====================
 REPO_ROOT = Path(__file__).resolve().parent
 EXCEL_PATH = REPO_ROOT / "Products Search Term.xlsx"
-SHEET_NAME = "Products Search Term"
+SHEET_NAME = "Sheet1"
 OUTPUT_PATH = REPO_ROOT / "preprocessed/Products Search Term.json"
 HEADER_ROW_INDEX = 1
 CONFIG_PATH = REPO_ROOT / "tools/local_pipeline_config.json"

--- a/index.html
+++ b/index.html
@@ -2649,7 +2649,7 @@ const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
 const LARGE_SHEET_ROW_THRESHOLD=100000;
 const LARGE_SHEET_CHUNK_SIZE=100000;
 const WORKBOOK_SHEET_PREFERENCES={
-  'products search term.xlsx':['Sheet1','Products Search Term','Search Term']
+  'products search term.xlsx':['Sheet1']
 };
 const ASIN_SKU_WORKBOOK='ASINwise SKU.xlsx';
 const ADVERTISED_PRODUCTS_WORKBOOK=ASIN_SKU_WORKBOOK;

--- a/tools/local_pipeline_config.example.json
+++ b/tools/local_pipeline_config.example.json
@@ -4,7 +4,7 @@
     {
       "name": "products-search-term",
       "excel_path": "C:/path/to/Products Search Term.xlsx",
-      "sheet_name": "Products Search Term",
+      "sheet_name": "Sheet1",
       "output_path": "preprocessed/Products Search Term.json",
       "csv_output_path": "preprocessed/Products Search Term.csv",
       "header_row_index": 1


### PR DESCRIPTION
### Motivation
- Ensure the Search Term dataset loads the expected worksheet when workbooks use a generic sheet name.
- Align frontend workbook preferences with the auto-update pipeline and local configuration for consistent behavior.
- Avoid ambiguous sheet-name matching by preferring a single canonical sheet name.

### Description
- Narrowed the frontend workbook preferences by setting `WORKBOOK_SHEET_PREFERENCES['products search term.xlsx']` to only include `Sheet1` in `index.html`.
- Updated the auto-update pipeline to target `Sheet1` by changing `SHEET_NAME` to `"Sheet1"` in `auto_update_dashboard.py`.
- Aligned the example local pipeline configuration by setting the `sheet_name` for the `products-search-term` workbook to `Sheet1` in `tools/local_pipeline_config.example.json`.

### Testing
- No automated tests were run for this change.
- Basic repository operations (file updates and commit) completed successfully as part of the change workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa04a97cc83208d8e67b5a603e548)