### PR TITLE
Set default sheet to 'Sheet 1' for Products Search Term

### DIFF
--- a/auto_update_dashboard.py
+++ b/auto_update_dashboard.py
@@ -23,7 +23,7 @@ from watchdog.observers import Observer
 # =====================
 REPO_ROOT = Path(__file__).resolve().parent
 EXCEL_PATH = REPO_ROOT / "Products Search Term.xlsx"
-SHEET_NAME = "Sheet1"
+SHEET_NAME = "Sheet 1"
 OUTPUT_PATH = REPO_ROOT / "preprocessed/Products Search Term.json"
 HEADER_ROW_INDEX = 1
 CONFIG_PATH = REPO_ROOT / "tools/local_pipeline_config.json"

--- a/index.html
+++ b/index.html
@@ -2649,7 +2649,7 @@ const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
 const LARGE_SHEET_ROW_THRESHOLD=100000;
 const LARGE_SHEET_CHUNK_SIZE=100000;
 const WORKBOOK_SHEET_PREFERENCES={
-  'products search term.xlsx':['Sheet1']
+  'products search term.xlsx':['Sheet 1','Sheet1']
 };
 const ASIN_SKU_WORKBOOK='ASINwise SKU.xlsx';
 const ADVERTISED_PRODUCTS_WORKBOOK=ASIN_SKU_WORKBOOK;


### PR DESCRIPTION
### Motivation
- Ensure the dashboard and auto-update pipeline load the correct worksheet when the workbook contains a sheet named `Sheet 1` instead of `Sheet1`.
- Align frontend workbook preferences with the auto-update script so both systems target the same default sheet name.

### Description
- Updated the default sheet constant in `auto_update_dashboard.py` by changing `SHEET_NAME` from `"Sheet1"` to `"Sheet 1"`.
- Updated `index.html` `WORKBOOK_SHEET_PREFERENCES` to prefer `'Sheet 1'` and include `'Sheet1'` as a fallback for `products search term.xlsx`.
- Modified files: `auto_update_dashboard.py` and `index.html`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607ae6249483208f1e1621b202bef9)