### PR TITLE
Date filter: show years with expandable months and remove year from month labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -4451,7 +4451,7 @@ function buildMonths(){
     const year=ym.slice(0,4);
     const monthIndex=Number(ym.slice(5))-1;
     const monthName=MONTH_NAMES[monthIndex]||ym;
-    return {ym, year, monthIndex, label:`${monthName} ${year}`, shortLabel:monthName};
+    return {ym, year, monthIndex, label:monthName, shortLabel:monthName};
   });
   state.monthOptions=monthOptions;
 
@@ -4539,7 +4539,7 @@ function updateMonthSummary(){
   }
   const n=state.monthSel.size;
   if(n===0){ sumEl.textContent='Date Range'; }
-  else if(n===1){ const k=[...state.monthSel][0]; sumEl.textContent=(state.monthOptions.find(o=>o.ym===k)||{}).label||k; }
+  else if(n===1){ const k=[...state.monthSel][0]; sumEl.textContent=(state.monthOptions.find(o=>o.ym===k)||{}).shortLabel||k; }
   else { sumEl.textContent=`${n} months`; }
 }
 function applyMonthFilters(force=false){


### PR DESCRIPTION
### Motivation
- Align the dashboard date slicer with a Power BI–style year-first view that lists only years initially and prevents months from showing the year text.
- Avoid displaying month labels like "January 2025" in the month list so months appear as names only when a year is expanded.

### Description
- Updated month option construction in `index.html` to set `label` to the month name only (removed appending the year). 
- Updated the date summary logic in `index.html` to use `shortLabel` when showing a single selected month so the summary displays the month name alone.
- Kept the existing year grouping and toggle behavior (the `+`/`-` toggle that expands a single year's months) intact without behavioral changes.
- Changes are contained in `index.html` (month label generation and summary rendering).

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the app served successfully. 
- Ran a headless UI check via a Playwright script that opened `/index.html` and captured a screenshot of the month filter, which completed successfully and produced `artifacts/month-filter.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c5cd4608832094a3cd5b131f198a)