### PR TITLE
Add Brands Campaign dashboard

### DIFF
--- a/Brands Campaign.html
+++ b/Brands Campaign.html
@@ -1,0 +1,6616 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Brands Campaign</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- Libs -->
+<script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.9.0/sql-wasm.js"></script>
+
+<style>
+:root{
+  --bg:#0f1216; --panel:#161b22; --text:#e7ecf3; --muted:#9aa6b2; --accent:#2563eb;
+  --ok:#36d399; --danger:#ef4444; --border:#273043; --chip:#1c2432;
+  --border-strong:color-mix(in srgb, var(--text) 40%, var(--border));
+  --shadow:0 8px 24px rgba(0,0,0,.35);
+  --header-grad: linear-gradient(180deg, rgba(255,255,255,.03) 0%, rgba(255,255,255,0) 100%);
+  --btnText:#fff;
+  --chartsGap:12px;
+  --modeBtnBg:#fff;
+  --modeIcon:#000;
+}
+body.light{
+  --bg:#f7f9fc; --panel:#ffffff; --text:#0f172a; --muted:#475569; --accent:#2563eb;
+  --ok:#059669; --danger:#dc2626; --border:#e2e8f0; --chip:#eef2f7;
+  --border-strong:color-mix(in srgb, var(--text) 35%, var(--border));
+  --shadow:0 6px 18px rgba(15,23,42,.08);
+  --header-grad: linear-gradient(180deg, rgba(15,23,42,.06) 0%, rgba(15,23,42,0) 100%);
+  --btnText:#0f172a;
+  --modeBtnBg:#000;
+  --modeIcon:#fff;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{margin:0;font:13.5px/1.45 system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial,"Noto Sans";color:var(--text);background:var(--bg);display:flex;flex-direction:column;min-height:100%}
+[hidden]{display:none !important}
+h1{margin:0;font-weight:800;letter-spacing:.2px}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+/* Buttons */
+button{border:1px solid var(--border);background:var(--panel);color:var(--text);padding:10px 12px;border-radius:12px;cursor:pointer;transition:transform .12s, box-shadow .25s, background .2s, border-color .2s}
+button:hover{transform:translateY(-1px)}
+button:disabled{opacity:.5;cursor:not-allowed}
+#resetFilters{display:none}
+.btn-filters,.btn-reset{display:inline-flex;align-items:center;gap:8px;padding:10px 16px;border-radius:999px;border:1px solid var(--border-strong);background:color-mix(in srgb,var(--chip) 70%, var(--panel));color:var(--text);font-weight:700;box-shadow:var(--shadow);transition:transform .15s ease, box-shadow .25s ease, background .2s ease}
+.btn-filters:hover,.btn-reset:hover{background:color-mix(in srgb,var(--chip) 90%, var(--panel));box-shadow:0 12px 28px rgba(0,0,0,.28)}
+.btn-filters:focus-visible,.btn-reset:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.btn-primary{display:inline-flex;align-items:center;gap:8px;background:linear-gradient(180deg, var(--accent), color-mix(in srgb, var(--accent) 85%, #000));color:#fff !important;border-color:transparent;box-shadow:0 6px 18px rgba(37,99,235,.25)}
+.btn-success{background:linear-gradient(180deg, var(--ok), color-mix(in srgb, var(--ok) 78%, #000)) !important;color:#fff !important;border-color:color-mix(in srgb, var(--ok) 60%, #000) !important;box-shadow:0 8px 22px color-mix(in srgb, var(--ok) 35%, transparent)}
+.btn-success:hover{box-shadow:0 14px 32px color-mix(in srgb, var(--ok) 45%, transparent);transform:translateY(-2px)}
+.btn-outline{display:inline-flex;align-items:center;gap:8px;background:transparent;border-color:var(--btnText);color:var(--btnText)}
+/* icon-only theme button */
+.btn-mode{display:inline-flex;align-items:center;gap:0;border-radius:14px;padding:10px;border:1px solid var(--modeBtnBg);background:var(--modeBtnBg);color:var(--modeIcon);width:42px;justify-content:center}
+.btn-icon{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;padding:10px;border-radius:12px;border:1px solid var(--border-strong);background:color-mix(in srgb,var(--panel) 85%, var(--chip));color:var(--muted);transition:background .2s ease,color .2s ease,transform .12s ease,box-shadow .25s ease}
+.btn-icon:hover{background:color-mix(in srgb,var(--chip) 92%, var(--panel));color:var(--text);transform:translateY(-1px);box-shadow:0 8px 18px rgba(15,23,42,.22)}
+.btn-icon:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+
+/* Header */
+.app-header{display:grid;grid-template-columns:auto minmax(260px,1fr) auto;align-items:center;gap:clamp(12px,2vw,24px);padding:12px clamp(14px,3vw,28px);border-bottom:1px solid var(--border);background:var(--header-grad);position:sticky;top:0;backdrop-filter:blur(6px);z-index:20}
+.header-left{display:flex;align-items:center;gap:14px;min-width:0}
+.header-title{display:flex;align-items:center;gap:10px;min-width:0}
+.header-title h1{font-size:clamp(20px,4vw,26px);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.actions{display:flex;gap:10px;align-items:center;flex-wrap:wrap;justify-content:flex-end}
+.header-search{display:flex;justify-content:center;min-width:0}
+.header-filter{grid-template-columns:1fr;min-width:0;width:min(420px,100%)}
+.header-filter label{text-align:center;justify-self:center}
+.header-search .dd{width:100%}
+.term-search{width:100%}
+.dd-search-mode{position:relative;width:100%}
+.dd-search-mode .dd-search-shell{position:relative;display:flex;flex-direction:column;gap:6px}
+.dd-search-mode .dd-search{width:100%;border:1px solid var(--border);background:var(--panel);color:var(--text);border-radius:12px;padding:12px 14px;font-size:15px;box-shadow:var(--shadow);transition:border-color .2s, box-shadow .25s}
+.dd-search-mode .dd-search:focus{outline:2px solid var(--accent);outline-offset:2px;border-color:var(--accent);box-shadow:0 10px 24px rgba(37,99,235,.22)}
+.dd-search-mode .dd-search::placeholder{color:var(--muted)}
+.dd-search-mode .dd-search-summary{font-size:12px;color:var(--muted);padding-left:2px}
+.dd-search-mode .dd-search-summary[data-state="all"]{display:none}
+.dd-search-mode .dd-panel{position:absolute;top:calc(100% + 8px);left:0;right:0;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);max-height:360px;overflow:auto;z-index:40}
+.dd-search-mode:not(.open) .dd-panel{display:none}
+.dd-search-mode .dd-head{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 12px;border-bottom:1px solid var(--border);position:sticky;top:0;background:var(--panel);z-index:2}
+.dd-search-mode .dd-head .select-all{display:flex;align-items:center;gap:8px;font-weight:700;color:var(--text)}
+.dd-search-mode .dd-head .select-all input[type=checkbox]{position:static;opacity:1;margin:0;accent-color:var(--accent);width:16px;height:16px}
+.dd-search-mode .dd-list{padding:6px}
+.dd-search-mode .dd-item{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:10px;transition:background .2s ease, transform .12s ease, box-shadow .25s ease}
+.dd-search-mode .dd-item:hover{background:color-mix(in srgb,var(--chip) 85%, transparent);transform:translateY(-1px);box-shadow:0 6px 16px rgba(15,23,42,.18)}
+.dd-search-mode .dd-only{display:none}
+.dd-search-mode .dd-left{flex:1;display:flex;align-items:center;gap:10px}
+.dd-search-mode .dd-left input[type=checkbox]{position:static;opacity:1;cursor:pointer;border:0;margin:0;accent-color:var(--accent);width:16px;height:16px}
+.dd-search-mode .dd-text{font-weight:600;color:var(--text)}
+.dd-search-mode .dd-item.is-selected{background:color-mix(in srgb,var(--accent) 25%, var(--chip));box-shadow:0 10px 24px rgba(37,99,235,.18)}
+.dd-search-mode .dd-item.is-selected .dd-text{color:var(--accent)}
+.dd-search-mode .dd-item.is-selected .dd-text::after{content:none}
+.dd-search-mode .dd-count{color:var(--muted);font-size:12px}
+.dd-search-mode .dd-empty{padding:18px 12px;font-weight:600;color:var(--muted)}
+.dataset-menu{position:relative;display:inline-flex;align-items:center}
+.dataset-menu-trigger{position:relative;display:inline-flex;align-items:center;justify-content:center;width:46px;height:46px;padding:0;border-radius:14px;border:0;background:transparent;color:var(--muted);cursor:pointer;transition:background .25s ease,color .2s ease,transform .12s ease,box-shadow .25s ease}
+.dataset-menu-trigger::after{content:"";position:absolute;inset:4px;border-radius:12px;opacity:0;background:color-mix(in srgb,var(--panel) 75%, transparent);transition:opacity .2s ease,background .25s ease;pointer-events:none}
+.dataset-menu-trigger:hover{color:var(--text);transform:translateY(-1px)}
+.dataset-menu-trigger:hover::after{opacity:1}
+.dataset-menu-trigger:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.dataset-menu-icon{position:relative;display:inline-block;width:26px;height:18px}
+.dataset-menu-icon::after{content:"";position:absolute;top:50%;right:2px;width:8px;height:8px;border-right:2px solid currentColor;border-bottom:2px solid currentColor;transform:translate(4px,-50%) rotate(-45deg) scale(.75);opacity:0;transition:opacity .25s ease,transform .32s ease}
+.dataset-menu-line{position:absolute;left:50%;width:100%;height:2px;background:currentColor;border-radius:999px;transition:transform .32s ease,opacity .2s ease,background .2s ease,top .32s ease,bottom .32s ease,width .32s ease;transform:translate(-50%,0);transform-origin:center}
+.dataset-menu-line.top{top:0}
+.dataset-menu-line.middle{top:50%;transform:translate(-50%,-50%)}
+.dataset-menu-line.bottom{bottom:0}
+.dataset-menu.is-open .dataset-menu-trigger{color:var(--accent);box-shadow:0 14px 30px rgba(37,99,235,.18);transform:none}
+.dataset-menu.is-open .dataset-menu-trigger::after{opacity:1;background:color-mix(in srgb,var(--accent) 18%, var(--panel))}
+.dataset-menu.is-open .dataset-menu-icon::after{opacity:1;transform:translate(4px,-50%) rotate(-45deg) scale(1)}
+.dataset-menu.is-open .dataset-menu-line{width:60%}
+.dataset-menu.is-open .dataset-menu-line.top{top:50%;transform:translate(-50%,-50%) rotate(45deg)}
+.dataset-menu.is-open .dataset-menu-line.middle{transform:translate(-50%,-50%);opacity:.65}
+.dataset-menu.is-open .dataset-menu-line.bottom{bottom:auto;top:50%;transform:translate(-50%,-50%) rotate(-45deg)}
+.dataset-menu-popup{position:absolute;top:calc(100% + 8px);right:0;min-width:220px;max-width:280px;padding:12px;border-radius:12px;border:1px solid var(--border);background:var(--panel);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:10px;z-index:130}
+.dataset-menu-popup[hidden]{display:none}
+.dataset-menu-head{display:flex;align-items:center;justify-content:space-between;gap:12px;font-weight:800;color:var(--text)}
+.dataset-menu-current{font-size:12px;font-weight:600;color:var(--muted)}
+.dataset-menu-list{display:flex;flex-direction:column;gap:6px}
+.dataset-menu-item{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:8px 10px;border-radius:10px;border:1px solid transparent;background:color-mix(in srgb,var(--panel) 92%, transparent);color:var(--text);font-weight:600;cursor:pointer;transition:background .2s ease,transform .12s ease,border-color .2s ease,box-shadow .25s ease}
+.dataset-menu-name{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dataset-menu-item:hover{background:color-mix(in srgb,var(--chip) 90%, var(--panel));transform:translateY(-1px);box-shadow:0 8px 20px rgba(15,23,42,.22)}
+.dataset-menu-item:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.dataset-menu-item .dataset-menu-meta{font-size:12px;font-weight:600;color:var(--muted)}
+.dataset-menu-item .dataset-menu-check{opacity:0;color:var(--accent);font-size:14px}
+.dataset-menu-item.is-active{border-color:color-mix(in srgb,var(--accent) 55%, var(--border));background:color-mix(in srgb,var(--accent) 18%, var(--panel));box-shadow:0 12px 28px rgba(37,99,235,.22)}
+.dataset-menu-item.is-active .dataset-menu-check{opacity:1}
+.dataset-menu-empty{padding:6px 0;font-weight:600;color:var(--muted);text-align:center}
+@media(max-width:900px){
+  .app-header{grid-template-columns:1fr;justify-items:center;text-align:center}
+  .header-left{justify-content:center}
+  .header-title{justify-content:center}
+  .actions{justify-content:center}
+  .header-search{width:100%}
+}
+body:not(.has-data) .app-header{display:none}
+
+/* Layout */
+#contentWrap{flex:1;display:flex;flex-direction:column;gap:14px;padding:12px clamp(14px,3vw,28px) 28px}
+body:not(.has-data) #contentWrap{justify-content:center;padding:0 18px}
+.empty-state{display:none;flex-direction:column;align-items:center;gap:18px;text-align:center;font-weight:600;color:var(--muted);line-height:1.6;max-width:520px;margin:0 auto;padding:0 18px;font-size:15px}
+.empty-state-lede{font-size:16px;color:var(--text);font-weight:800}
+.empty-state-actions{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
+.empty-dataset-options{display:flex;flex-direction:column;gap:10px;width:100%;max-width:360px}
+.empty-dataset-btn{width:100%;text-align:left;border:1px solid var(--border-strong);background:color-mix(in srgb,var(--panel) 85%, var(--chip));color:var(--text);border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;box-shadow:var(--shadow);transition:background .2s ease,color .2s ease,transform .12s ease,box-shadow .25s ease}
+.empty-dataset-btn:hover{background:color-mix(in srgb,var(--chip) 90%, var(--panel));transform:translateY(-1px);box-shadow:0 10px 24px rgba(15,23,42,.22)}
+.empty-dataset-btn:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
+.empty-dataset-btn.is-active{background:color-mix(in srgb,var(--accent) 18%, var(--panel));border-color:color-mix(in srgb,var(--accent) 55%, var(--border));color:var(--accent);box-shadow:0 12px 28px rgba(37,99,235,.22)}
+.empty-state-note{margin:0;color:var(--muted)}
+.empty-open-btn{border:1px solid var(--accent);background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 85%,#000));color:#fff;font-weight:700;padding:10px 18px;border-radius:999px;cursor:pointer;box-shadow:0 10px 26px rgba(37,99,235,.22);transition:transform .12s ease,box-shadow .25s ease}
+.empty-open-btn:hover{transform:translateY(-1px);box-shadow:0 14px 32px rgba(37,99,235,.28)}
+.empty-open-btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+body:not(.has-data) #emptyState{display:flex;align-items:center;justify-content:center;min-height:60vh}
+body.has-data #emptyState{display:none}
+body:not(.has-data) #topLine,
+body:not(.has-data) #kpiSection,
+body:not(.has-data) #pivotSection{display:none !important}
+
+/* Topline */
+.topline{display:flex;flex-direction:column;align-items:flex-start;gap:12px;padding:8px clamp(14px,3vw,28px)}
+body.has-data #tipPill{display:none !important}
+.topline-controls{display:flex;flex-wrap:wrap;align-items:center;gap:12px;width:100%}
+.dataset-meta{display:flex;flex-wrap:wrap;gap:10px;width:100%}
+.dataset-meta .meta-card{display:flex;flex-direction:column;gap:4px;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:var(--panel);box-shadow:var(--shadow)}
+.dataset-meta .meta-label{font-size:11px;font-weight:800;letter-spacing:.5px;text-transform:uppercase;color:var(--muted)}
+.dataset-meta .meta-value{font-weight:800;color:var(--text)}
+.pivot-tabs-bar{display:flex;align-items:center;justify-content:flex-start;flex:1 1 auto;min-width:0}
+.pivot-tabs{display:inline-flex;align-items:center;gap:6px;padding:4px;border-radius:14px;border:1px solid var(--border);background:var(--panel);box-shadow:var(--shadow)}
+.pivot-tab{border:0;background:transparent;color:var(--muted);font-weight:700;padding:8px 16px;border-radius:10px;cursor:pointer;transition:color .2s, background .2s, transform .12s;min-width:0}
+.pivot-tab:hover{color:var(--text);background:var(--chip);transform:translateY(-1px)}
+.pivot-tab.is-active{color:#fff;background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 85%,#000))}
+.pivot-tab:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.pill{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;background:var(--chip);border:1px solid var(--border);border-radius:999px;color:var(--muted)}
+.months-wrap{display:inline-flex;align-items:center;gap:6px;margin-left:auto}
+.month-dd{position:relative}
+.month-dd .dd-control{min-width:160px;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border:1px solid var(--border);border-radius:10px;background:var(--panel);cursor:pointer}
+.month-dd .dd-panel{position:absolute;top:calc(100% + 6px);right:0;z-index:40;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);width:240px;display:none;max-height:360px;overflow:auto;scrollbar-width:none;-ms-overflow-style:none}
+.month-dd .dd-panel::-webkit-scrollbar{display:none}
+.month-dd.open .dd-panel{display:block}
+.month-tablist{display:flex;align-items:center;gap:6px;padding:6px;border-bottom:1px solid var(--border);background:color-mix(in srgb,var(--panel) 92%, var(--chip))}
+.month-tab-btn{flex:1 1 0;border:0;background:transparent;color:var(--muted);font-weight:700;padding:8px 10px;border-radius:8px;cursor:pointer;transition:color .2s, background .2s, transform .12s}
+.month-tab-btn:hover{color:var(--text);background:color-mix(in srgb,var(--chip) 85%, transparent);transform:translateY(-1px)}
+.month-tab-btn.is-active{color:#fff;background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 82%, #000));box-shadow:0 8px 18px rgba(37,99,235,.22);transform:none}
+.month-tab-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.month-tab-panel[hidden]{display:none}
+.month-row{display:grid;grid-template-columns:auto 1fr;gap:10px;align-items:center;padding:8px 12px}
+.month-row:hover{background:var(--chip)}
+.month-row input{accent-color:var(--accent)}
+.month-name{font-weight:700;color:var(--text)}
+.month-year-group{border-bottom:1px solid var(--border)}
+.month-year-row{display:flex;align-items:center;gap:8px;padding:8px 12px;font-weight:700;color:var(--text)}
+.month-year-toggle{width:24px;height:24px;border-radius:6px;border:1px solid var(--border);background:var(--panel);color:var(--text);font-weight:800;line-height:1;display:inline-flex;align-items:center;justify-content:center;cursor:pointer}
+.month-year-toggle:hover{background:color-mix(in srgb,var(--chip) 80%, transparent)}
+.month-year-toggle.is-open{background:var(--accent);color:#fff;border-color:transparent}
+.month-year-months{padding-left:32px}
+.month-range-panel{border:1px solid var(--border);border-radius:12px;padding:12px 14px 14px;background:color-mix(in srgb,var(--panel) 85%, var(--chip));box-shadow:inset 0 1px 0 color-mix(in srgb,var(--text) 6%, transparent);display:flex;flex-direction:column;gap:12px}
+.month-range-fields{display:flex;flex-direction:column;gap:12px}
+.month-range-fields label{display:flex;flex-direction:column;gap:4px;font-weight:600;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.4px}
+.month-range-fields input{border:1px solid var(--border);border-radius:8px;padding:8px 10px;background:var(--panel);color:var(--text);width:100%}
+.month-range-actions{display:flex;gap:8px;margin-top:10px}
+.month-range-apply,.month-range-cancel{flex:1;border-radius:9px;font-weight:700;padding:8px 12px}
+.month-range-apply{background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 80%,#000));color:#fff;border-color:transparent;box-shadow:0 8px 20px rgba(37,99,235,.25)}
+.month-range-apply:hover{box-shadow:0 12px 24px rgba(37,99,235,.3)}
+.month-range-cancel{background:transparent;border:1px solid var(--border-strong);color:var(--muted)}
+.month-range-cancel:hover{background:color-mix(in srgb,var(--chip) 85%, transparent)}
+
+/* KPIs */
+.kpis{padding:4px clamp(14px,3vw,26px) 8px;display:grid;grid-template-columns:repeat(8,minmax(120px,1fr));gap:10px}
+.kpi{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:8px 10px;box-shadow:var(--shadow);min-height:68px;display:flex;flex-direction:column;justify-content:space-between}
+.kpi .label{font-weight:700;color:var(--muted);font-size:12.5px}
+.kpi .value{font-size:20px;font-weight:700;letter-spacing:.1px}
+.kpi.small .value{font-size:20px}
+
+
+/* Pivot table */
+.pivot{padding:6px clamp(14px,3vw,26px) 20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:var(--chartsGap);align-items:start;grid-auto-rows:var(--pivot-auto-rows,auto);grid-auto-flow:row dense}
+.pivot[data-mode="overview"] #pivotCustTypeCard,
+.pivot[data-mode="overview"] #pivotPlacementCard{display:none !important}
+.pivot:not([data-mode="targeting"]) .pivot-conversion{display:none !important}
+@media(min-width:960px){
+  .pivot[data-mode="overview"]{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .pivot[data-mode="overview"] #pivotStoreCard,
+  .pivot[data-mode="overview"] #pivotPortfolioCard{grid-column:1 / 2;}
+  .pivot[data-mode="overview"] #pivotLoCard,
+  .pivot[data-mode="overview"] #pivotCatCard{grid-column:2 / 3;}
+  .pivot[data-mode="overall"]{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .pivot[data-mode="overall"] .pivot-card{grid-column:1 / -1;}
+  .pivot[data-mode="overall"] .pivot-overall-left{grid-column:1 / 2;}
+  .pivot[data-mode="overall"] .pivot-overall-right{grid-column:2 / 3;}
+  .pivot[data-mode="campaignPortfolio"]{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .pivot[data-mode="targeting"]{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .pivot[data-mode="targeting"] .pivot-targeting-left{grid-column:1 / 2;}
+  .pivot[data-mode="targeting"] .pivot-targeting-right{grid-column:2 / 3;}
+}
+.chart-card{position:relative;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px 12px 10px;box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:visible}
+.chart-title{font-weight:700;margin-bottom:8px;color:var(--muted);display:flex;align-items:center;justify-content:space-between;gap:10px}
+.chart-title-text{flex:1;min-width:0}
+.chart-title-actions{display:inline-flex;align-items:center;gap:6px}
+.pivot-action-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border-radius:9px;border:1px solid var(--border-strong);background:color-mix(in srgb,var(--panel) 75%, var(--chip));color:var(--muted);cursor:pointer;transition:background .2s ease, color .2s ease, transform .12s ease, box-shadow .25s ease, border-color .2s ease}
+.pivot-copy-btn .pivot-copy-icon{display:inline-flex;align-items:center;justify-content:center;line-height:0}
+.pivot-action-btn .pivot-action-icon{display:inline-flex;align-items:center;justify-content:center;line-height:0}
+.pivot-action-btn svg{width:16px;height:16px;display:block;fill:currentColor}
+.pivot-action-btn:hover{background:color-mix(in srgb,var(--chip) 88%, var(--panel));color:var(--text);transform:translateY(-1px);box-shadow:0 6px 16px rgba(15,23,42,.2)}
+.pivot-action-btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.pivot-action-btn:disabled{opacity:.5;cursor:not-allowed;box-shadow:none;transform:none}
+.pivot-action-btn.is-active{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 55%, var(--border));background:color-mix(in srgb,var(--accent) 18%, var(--panel));box-shadow:0 6px 18px rgba(37,99,235,.22)}
+.pivot-copy-btn{position:relative}
+.pivot-copy-btn.is-copied{color:var(--ok);border-color:color-mix(in srgb,var(--ok) 60%, var(--border))}
+.pivot-copy-btn.is-copied::after{content:"Copied!";position:absolute;top:calc(100% + 8px);right:0;border-radius:8px;border:1px solid var(--border);background:var(--panel);padding:6px 10px;color:var(--ok);font-size:11px;font-weight:700;white-space:nowrap;box-shadow:0 10px 26px rgba(15,23,42,.18);pointer-events:none;z-index:10}
+.pivot-clear-btn{color:var(--danger);border-color:color-mix(in srgb,var(--danger) 45%, var(--border))}
+.pivot-clear-btn:hover{color:#fff;background:linear-gradient(180deg,var(--danger),color-mix(in srgb,var(--danger) 82%, #000));border-color:transparent;box-shadow:0 10px 22px rgba(220,38,38,.25)}
+.pivot-card{margin:0;width:100%}
+.pivot-card+.pivot-card{margin-top:0}
+.pivot-extra-card{grid-column:1 / -1}
+.pivot-card-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
+.pivot-card-head .chart-title{margin-bottom:0}
+.pivot-filter-popup{position:fixed;z-index:130;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);padding:14px;display:flex;flex-direction:column;gap:12px;min-width:240px;max-width:320px;max-height:420px;overflow:hidden}
+.pivot-filter-popup[hidden]{display:none}
+.pivot-filter-popup-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.pivot-filter-popup-title{font-weight:800;font-size:14px;color:var(--text);letter-spacing:.2px}
+.pivot-filter-popup-close{border:0;background:transparent;color:var(--muted);cursor:pointer;border-radius:8px;padding:4px;line-height:0;display:flex;align-items:center;justify-content:center;transition:background .15s ease,color .15s ease}
+.pivot-filter-popup-close:hover{background:color-mix(in srgb,var(--chip) 85%, transparent);color:var(--text)}
+.pivot-filter-search-row{display:flex;align-items:center;gap:10px}
+.pivot-filter-select-all{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:600;color:var(--muted)}
+.pivot-filter-select-all input{width:16px;height:16px;accent-color:var(--accent)}
+.pivot-filter-search{flex:1;border:1px solid var(--border);border-radius:9px;padding:8px 10px;background:var(--panel);color:var(--text);font-size:13px}
+.pivot-filter-search::placeholder{color:var(--muted)}
+.pivot-filter-options{flex:1;overflow:auto;display:flex;flex-direction:column;gap:6px;padding-right:2px}
+.pivot-filter-option{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:8px 10px;border-radius:10px;background:transparent;transition:background .15s ease,color .15s ease}
+.pivot-filter-option:hover{background:color-mix(in srgb,var(--chip) 85%, transparent)}
+.pivot-filter-option input{accent-color:var(--accent);width:16px;height:16px}
+.pivot-filter-option-label{display:flex;align-items:center;gap:8px;font-weight:600;color:var(--text)}
+.pivot-filter-option-value{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.pivot-filter-option-metric{font-size:12px;color:var(--muted)}
+.pivot-filter-empty{text-align:center;font-weight:600;color:var(--muted);padding:18px 6px;border-radius:10px;background:color-mix(in srgb,var(--chip) 80%, transparent)}
+.pivot-filter-footer{display:flex;justify-content:flex-end}
+.pivot-filter-clear{border:1px solid var(--border-strong);background:transparent;color:var(--muted);border-radius:9px;font-weight:700;padding:8px 12px;cursor:pointer;transition:background .15s ease,color .15s ease}
+.pivot-filter-clear:hover{background:color-mix(in srgb,var(--chip) 85%, transparent);color:var(--text)}
+.advertised-table{width:100%;border-collapse:collapse;font-size:13px;line-height:1.5}
+.advertised-table thead th{padding:8px 10px;text-align:left;border-bottom:1px solid var(--border);color:var(--muted);font-size:12px;letter-spacing:.4px;text-transform:uppercase;font-weight:700}
+.advertised-table tbody td{padding:9px 10px;border-bottom:1px solid var(--border);color:var(--text);font-weight:600;vertical-align:top}
+.advertised-table tbody tr:hover{background:color-mix(in srgb,var(--chip) 85%, transparent)}
+.advertised-table tbody tr:last-child td{border-bottom:0}
+.advertised-table.is-loading tbody td{color:var(--muted);font-style:italic}
+.advertised-empty{padding:10px 12px;color:var(--muted);font-weight:600}
+.advertised-placeholder{color:var(--muted);font-weight:500}
+.pivot-date-tabs{display:flex;align-items:center;gap:6px;padding:4px;border-radius:10px;border:1px solid var(--border);background:color-mix(in srgb,var(--panel) 80%, var(--chip));box-shadow:inset 0 1px 0 color-mix(in srgb,var(--text) 4%, transparent)}
+.pivot-date-tab{flex:1 1 0;border:0;background:transparent;color:var(--muted);font-weight:700;padding:8px 12px;border-radius:8px;cursor:pointer;transition:color .2s ease, background .2s ease, transform .12s ease}
+.pivot-date-tab:hover{color:var(--text);background:color-mix(in srgb,var(--chip) 85%, transparent);transform:translateY(-1px)}
+.pivot-date-tab.is-active{color:#fff;background:linear-gradient(180deg,var(--accent),color-mix(in srgb,var(--accent) 82%, #000));box-shadow:0 8px 18px rgba(37,99,235,.22);transform:none}
+.pivot-date-tab:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.pivot-date-range{margin-top:12px;padding-top:12px;border-top:1px solid var(--border);display:flex;flex-direction:column;gap:10px}
+.pivot-date-range h4{margin:0;font-size:12px;letter-spacing:.4px;text-transform:uppercase;color:var(--muted)}
+.pivot-date-range-fields{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.pivot-date-range-fields label{display:flex;flex-direction:column;gap:4px;font-weight:600;font-size:12px;color:var(--muted)}
+.pivot-date-range-fields input{border:1px solid var(--border);border-radius:8px;padding:8px 10px;background:var(--panel);color:var(--text)}
+.pivot-date-range-note{font-size:11px;color:var(--muted)}
+.pivot-pagination{display:inline-flex;align-items:center;gap:8px}
+.pivot-pagination.is-idle{opacity:.7}
+.pivot-pagination[hidden]{display:none !important}
+.pivot-nav-btn{width:30px;height:30px;min-width:30px;min-height:30px;display:grid;place-items:center;padding:0;border-radius:8px;font-size:16px;line-height:1}
+.pivot-nav-btn:disabled{opacity:.45;cursor:not-allowed}
+.pivot-nav-label{font-weight:700;color:var(--muted);font-size:12px;white-space:nowrap}
+.pivot-body{margin-top:10px;overflow-y:auto;overflow-x:hidden;max-height:clamp(360px,55vh,520px);position:relative;border-radius:10px;background:var(--panel)}
+.pivot-note{margin:2px 0 8px;color:var(--muted);font-size:12px;font-weight:600;line-height:1.35;}
+.pivot-table{width:100%;border-collapse:collapse;min-width:320px;font-variant-numeric:tabular-nums}
+.pivot-table thead th{padding:10px 12px;border-bottom:0;font-weight:700;color:var(--muted);font-size:12.5px;letter-spacing:.3px;text-transform:uppercase;position:sticky;top:0;background:var(--panel);z-index:3;text-align:right;box-shadow:inset 0 -2px 0 var(--border-strong)}
+.pivot-table thead th.pivot-sortable{cursor:pointer;user-select:none}
+.pivot-table thead th.pivot-sortable:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:8px}
+.pivot-sort-label{display:inline-flex;align-items:center;gap:6px;justify-content:flex-end}
+.pivot-table thead th:first-child .pivot-sort-label{justify-content:flex-start}
+.pivot-sort-indicator{font-size:10px;opacity:.75}
+.pivot-table thead th:first-child{text-align:left}
+.pivot-table thead th.pivot-sku{text-align:left}
+.pivot-table thead th.pivot-brand{text-align:left}
+.pivot-table thead th.pivot-acos{text-align:right}
+.pivot-table thead th.pivot-acos-bar{padding-left:0;text-align:left;width:90px}
+.pivot-table tbody th{padding:8px 12px;border-bottom:1px solid var(--border);text-align:left;font-weight:600;color:var(--text);white-space:normal;word-break:break-word;overflow-wrap:anywhere}
+.pivot-label-btn{display:inline-flex;align-items:center;gap:6px;width:100%;padding:0;margin:0;border:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
+.pivot-label-btn:hover,.pivot-label-btn:focus-visible{color:var(--accent)}
+.pivot-label-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:6px}
+.pivot-label-text{display:inline-block}
+.pivot-table tbody td{padding:8px 12px;border-bottom:1px solid var(--border);vertical-align:middle}
+.pivot-table.has-grand-total tbody tr:last-child th,.pivot-table.has-grand-total tbody tr:last-child td{border-bottom:0}
+.pivot-table tbody tr:hover{background:var(--chip)}
+.pivot-table td.pivot-num{text-align:right;font-weight:600;font-variant-numeric:tabular-nums}
+.pivot-table td.pivot-sku{text-align:left;white-space:normal;word-break:break-word}
+.pivot-table td.pivot-brand{text-align:left;white-space:normal;word-break:break-word}
+.pivot-table tfoot th,.pivot-table tfoot td{padding:12px;border:0;font-weight:800;background:var(--panel);position:sticky;bottom:0;z-index:2;border-top:3px double var(--border-strong);box-shadow:none}
+.pivot-table tfoot th{text-align:left}
+.pivot-table tfoot td{text-align:right}
+.pivot-table tfoot td.pivot-acos{padding-right:12px}
+.pivot-table tfoot td.pivot-acos-bar{text-align:left;padding-left:0}
+.pivot-table tfoot td .pivot-amount-total{font-weight:800}
+.pivot-table td.pivot-acos{color:var(--text);vertical-align:middle;text-align:right;white-space:nowrap}
+.pivot-table td.pivot-acos .pivot-amount{display:inline-block;min-width:56px;text-align:right;font-weight:600}
+.pivot-table td.pivot-acos.pivot-acos-empty{color:var(--muted)}
+.pivot-table td.pivot-acos-bar{padding-left:0;padding-right:12px;vertical-align:middle}
+.pivot-table td.pivot-acos-bar .pivot-bar{min-width:64px}
+.pivot-table td.pivot-acos-bar.pivot-acos-empty{opacity:.4}
+.pivot-bar-fill.acos{background:linear-gradient(90deg,rgba(239,68,68,.9),rgba(220,38,38,.95))}
+.pivot-table tr.pivot-total th,.pivot-table tr.pivot-total td{font-weight:800}
+.pivot-empty{text-align:center;padding:24px 12px;color:var(--muted);font-weight:600;letter-spacing:.2px}
+
+
+.pivot-metric{display:flex;flex-direction:column;gap:6px}
+.pivot-amount{font-weight:600;font-size:13.5px}
+.pivot-amount-total{font-weight:800;font-size:14px}
+
+.pivot-bar{position:relative;height:8px;border-radius:999px;background:var(--chip);overflow:hidden}
+.pivot-bar-fill{position:absolute;inset:0;border-radius:inherit;opacity:.9}
+.pivot-bar-fill.spend{background:linear-gradient(90deg,rgba(37,99,235,.95),rgba(30,64,175,.95))}
+.pivot-bar-fill.sales{background:linear-gradient(90deg,rgba(16,185,129,.7),rgba(5,150,105,.85))}
+
+/* Loader */
+#statusArea{display:none}
+#statusArea.show{position:fixed;inset:0;z-index:1000;display:grid;place-items:center;background:radial-gradient(900px 400px at 20% -10%, color-mix(in srgb, #ffffff 4%, var(--bg)) 0%, var(--bg) 45%)}
+.loader{display:flex;align-items:center;gap:14px;padding:16px 18px;border:1px dashed var(--border);border-radius:14px;background:var(--chip);box-shadow:var(--shadow)}
+.spinner{width:22px;height:22px;border-radius:50%;border:3px solid rgba(255,255,255,.25);border-top-color:var(--accent);animation:spin .9s linear infinite}
+.status-progress{margin-top:4px;font-size:12px;font-weight:600;color:var(--muted);letter-spacing:.25px}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* Modal (filters) */
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:50}
+.modal.open{display:flex}
+.modal-card{width:min(1120px,94vw);max-height:86vh;background:var(--panel);border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow);padding:18px;overflow:visible}
+.modal-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+.modal-actions{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+.modal-card{position:relative}
+.modal-card::before{content:"";position:absolute;inset:-1px;border-radius:inherit;padding:1px;background:linear-gradient(135deg,color-mix(in srgb,var(--accent) 35%, transparent) 0%,transparent 42%,color-mix(in srgb,var(--accent) 28%, transparent) 100%);-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);-webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none}
+.modal-head{padding-bottom:12px;margin-bottom:16px;border-bottom:1px solid var(--border-strong)}
+.modal-head h3{margin:0;font-size:20px;font-weight:800;letter-spacing:.4px;text-transform:uppercase;color:var(--text)}
+.filters{display:grid;gap:14px;grid-template-columns:repeat(12, minmax(0,1fr));overflow:visible;padding:12px;border:1px solid var(--border);border-radius:14px;background:color-mix(in srgb,var(--panel) 90%, var(--chip))}
+.filter{display:grid;gap:6px;min-width:0;grid-column:span 4}
+.filter.grow{grid-column:span 8}
+.filter.search{grid-column:span 12}
+.filter label{font-weight:700;color:var(--text);text-transform:uppercase;letter-spacing:.4px;font-size:12px}
+.filter label::after{content:"";display:block;width:18px;height:2px;border-radius:999px;background:var(--accent);margin-top:4px}
+.filter.is-highlighted{outline:2px solid color-mix(in srgb,var(--accent) 65%, transparent);outline-offset:2px;animation:filterPulse 1.2s ease-in-out;box-shadow:0 0 0 6px color-mix(in srgb,var(--accent) 25%, transparent)}
+@keyframes filterPulse{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 28%, transparent);}50%{box-shadow:0 0 0 12px color-mix(in srgb,var(--accent) 18%, transparent);}100%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 0%, transparent);}}
+
+/* Multi-select */
+.dd{position:relative}
+.dd-control{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);cursor:pointer;min-height:40px}
+.dd-summary{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dd-chev{opacity:.8}
+.dd-panel{position:absolute;top:calc(100% + 8px);left:0;z-index:100;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);width:min(420px, 90vw);max-height:360px;display:none;overflow:auto}
+.dd.open .dd-panel{display:block}
+.dd-head{display:grid;grid-template-columns: 1fr 1.4fr 90px;gap:6px;align-items:center;padding:8px;border-bottom:1px solid var(--border);background:var(--chip);border-top-left-radius:12px;border-top-right-radius:12px}
+.dd-head .select-all{display:flex;align-items:center;gap:8px;font-weight:700}
+.dd-head input[type="search"]{width:100%;border:1px solid var(--border);border-radius:8px;padding:8px 10px;background:var(--panel);color:var(--text)}
+.dd-head .rc{justify-self:end;color:var(--muted);font-weight:700}
+.dd-list{overflow:auto;padding:6px}
+.dd-item{display:grid;grid-template-columns:1fr auto 60px;gap:8px;align-items:center;padding:6px;border-radius:8px}
+.dd-item:hover{background:var(--chip)}
+.dd-left{display:flex;align-items:center;gap:8px;min-width:0}
+.dd-text{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:30ch}
+.dd-only{border:1px solid var(--border);background:var(--chip);color:var(--muted);border-radius:8px;padding:4px 8px;cursor:pointer}
+.dd-count{text-align:right;color:var(--muted);font-variant-numeric:tabular-nums}
+.dd-empty{padding:12px;text-align:center;color:var(--muted);font-weight:600;display:none}
+.dd.no-results .dd-list{display:none}
+.dd.no-results .dd-empty{display:block}
+
+/* KPI sparklines */
+.kpi{position:relative;overflow:hidden;transition:transform .18s ease, box-shadow .25s ease;padding-right:calc(10px + clamp(54px,45%,90px))}
+.kpi:hover{transform:translateY(-3px);box-shadow:0 12px 28px rgba(15,23,42,.28)}
+.kpi-spark{position:absolute;top:10px;right:10px;bottom:8px;width:clamp(54px,45%,90px);pointer-events:none;opacity:0;transition:opacity .25s ease}
+.kpi:hover .kpi-spark{opacity:.9}
+.kpi.small{padding-right:calc(8px + clamp(48px,48%,82px))}
+.kpi.small .kpi-spark{right:8px;width:clamp(48px,48%,82px)}
+
+/* Pivot animations */
+.pivot-animate-forward{animation:pivotSlideLeft .4s ease}
+.pivot-animate-backward{animation:pivotSlideRight .4s ease}
+@keyframes pivotSlideRight{from{opacity:0;transform:translateX(-24px);}to{opacity:1;transform:translateX(0);}}
+@keyframes pivotSlideLeft{from{opacity:0;transform:translateX(24px);}to{opacity:1;transform:translateX(0);}}
+
+/* responsive */
+@media (max-width:980px){.kpis{grid-template-columns:repeat(4,1fr)}}
+@media (max-width:620px){.kpis{grid-template-columns:repeat(2,1fr)}}
+</style>
+</head>
+<body>
+
+<header id="appHeader" class="app-header">
+  <div class="header-left">
+    <div class="dataset-menu" id="datasetMenuContainer">
+      <button id="datasetMenuBtn" type="button" class="dataset-menu-trigger" title="Select dataset" aria-label="Select dataset" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">Select dataset</span>
+        <span class="dataset-menu-icon" aria-hidden="true">
+          <span class="dataset-menu-line top"></span>
+          <span class="dataset-menu-line middle"></span>
+          <span class="dataset-menu-line bottom"></span>
+        </span>
+      </button>
+      <div id="datasetMenu" class="dataset-menu-popup" role="menu" aria-orientation="vertical" hidden>
+        <div class="dataset-menu-head">
+          <span>Datasets</span>
+          <span id="datasetMenuCurrent" class="dataset-menu-current">No dataset loaded</span>
+        </div>
+        <div id="datasetMenuList" class="dataset-menu-list" role="none"></div>
+        <div id="datasetMenuEmpty" class="dataset-menu-empty" hidden>No built-in datasets found</div>
+      </div>
+    </div>
+    <div class="header-title"><h1 id="datasetTitle">Brands Campaign</h1></div>
+  </div>
+  <div class="header-search">
+    <div class="filter header-filter term-search" data-col-wrapper="term">
+      <label data-col-label="term" data-default="Search Term" class="sr-only">Search Term</label>
+      <div id="termMS" class="dd dd-search-mode" data-placeholder="Search terms"></div>
+    </div>
+  </div>
+  <div class="actions">
+    <button id="resetFilters" class="btn-reset">Reset</button>
+    <button id="openFilters" class="btn-filters" style="display:none">Filters</button>
+    <button id="pickLocalBtn" class="btn-primary btn-success">Open XLSX</button>
+    <input id="fileInput" type="file" accept=".xlsx,.xls" hidden />
+    <button id="downloadCsvBtn" class="btn-primary btn-success" disabled>Download CSV</button>
+    <button id="themeBtn" class="btn-mode" title="Toggle dark/light" aria-label="Toggle theme"><span class="icon">🌙</span></button>
+  </div>
+</header>
+
+<main id="contentWrap">
+  <div id="emptyState" class="empty-state" role="status" aria-live="polite">
+    <p class="empty-state-lede">📊 Select a dataset to explore the dashboards.</p>
+    <div class="empty-state-actions">
+      <div id="emptyDatasetOptions" class="empty-dataset-options" role="group" aria-label="Available datasets"></div>
+      <div>
+        <p class="empty-state-note">or load your own file</p>
+        <button id="emptyOpenBtn" type="button" class="empty-open-btn">Open XLSX</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="topline" id="topLine">
+    <div class="pill" id="tipPill" hidden>📊 Choose a dataset from the menu or click <b>Open XLSX</b> to load a file.</div>
+    <div class="topline-controls">
+      <div class="pivot-tabs-bar" id="pivotTabsBar" hidden>
+        <div id="pivotTabs" class="pivot-tabs" role="tablist" aria-label="Pivot views">
+          <button type="button" class="pivot-tab is-active" data-tab="overview" role="tab" aria-selected="true">Overview Pivots</button>
+          <button type="button" class="pivot-tab" data-tab="overall" role="tab" aria-selected="false" tabindex="-1">Overall Pivots</button>
+          <button type="button" class="pivot-tab" data-tab="campaignPortfolio" role="tab" aria-selected="false" tabindex="-1">Campaign / Ad Group</button>
+          <button type="button" class="pivot-tab" data-tab="targeting" role="tab" aria-selected="false" tabindex="-1">Targeting ASIN / CAT</button>
+        </div>
+      </div>
+      <div class="months-wrap" id="monthsWrap" hidden>
+        <div id="monthFilter" class="month-dd">
+          <div class="dd-control"><span class="dd-summary">Date Range</span><span class="dd-chev">▾</span></div>
+          <div class="dd-panel">
+            <div id="monthTabList" class="month-tablist" role="tablist" aria-label="Date filter tabs">
+              <button type="button" class="month-tab-btn is-active" data-tab="months" role="tab" aria-selected="true">Months</button>
+              <button type="button" class="month-tab-btn" data-tab="custom" role="tab" aria-selected="false" tabindex="-1">Custom</button>
+            </div>
+            <div id="monthList" class="month-tab-panel" data-panel="months"></div>
+            <div id="customRangePanel" class="month-range-panel month-tab-panel" data-panel="custom" hidden>
+              <div class="month-range-fields">
+                <label>
+                  <span>From</span>
+                  <input type="date" id="customRangeStart" />
+                </label>
+                <label>
+                  <span>To</span>
+                  <input type="date" id="customRangeEnd" />
+                </label>
+              </div>
+              <div class="month-range-actions">
+                <button type="button" id="customRangeApply" class="month-range-apply">Apply</button>
+                <button type="button" id="customRangeCancel" class="month-range-cancel">Cancel</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="dataset-meta" id="datasetMeta" hidden>
+      <div class="meta-card" aria-live="polite">
+        <span class="meta-label">Data till</span>
+        <span class="meta-value" id="dataTillValue">—</span>
+      </div>
+      <div class="meta-card" aria-live="polite">
+        <span class="meta-label">Last Updated</span>
+        <span class="meta-value" id="lastUpdatedValue">—</span>
+      </div>
+    </div>
+  </div>
+
+  <section class="status" id="statusArea" aria-live="polite">
+    <div class="loader">
+      <div class="spinner"></div>
+      <div>
+        <strong>Processing data</strong>
+        <div id="statusProgress" class="status-progress" aria-live="polite"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- KPIs -->
+  <section class="kpis" id="kpiSection" hidden>
+  <div class="kpi" data-kpi="spend"><div class="label">Spend</div><div class="value" id="kpiSpend">—</div></div>
+  <div class="kpi" data-kpi="revenue"><div class="label">Sales</div><div class="value" id="kpiRevenue">—</div></div>
+  <div class="kpi small" data-kpi="acos"><div class="label">ACOS</div><div class="value" id="kpiACOS">—</div></div>
+  <div class="kpi" data-kpi="clicks"><div class="label">Clicks</div><div class="value" id="kpiClicks">—</div></div>
+  <div class="kpi" data-kpi="impressions"><div class="label">Impressions</div><div class="value" id="kpiImpr">—</div></div>
+  <div class="kpi small" data-kpi="ctr"><div class="label">CTR</div><div class="value" id="kpiCTR">—</div></div>
+  <div class="kpi" data-kpi="roas"><div class="label">ROAS</div><div class="value" id="kpiROAS">—</div></div>
+  <div class="kpi" data-kpi="avgcpc"><div class="label">Avg CPC</div><div class="value" id="kpiAvgCPC">—</div></div>
+</section>
+
+  <!-- Pivot Table -->
+  <section class="pivot" id="pivotSection" hidden>
+  <div class="chart-card pivot-card pivot-overall-left" id="pivotStoreCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Store Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableStore" title="Copy Store Performance Pivot table" aria-label="Copy Store Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableStore" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card" id="pivotPortfolioCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Portfolio Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTablePortfolio" title="Copy Portfolio Performance Pivot table" aria-label="Copy Portfolio Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTablePortfolio" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-left" id="pivotLoCard">
+    <div class="chart-title">
+      <span class="chart-title-text">LO Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableLo" title="Copy LO Performance Pivot table" aria-label="Copy LO Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableLo" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-right" id="pivotCatCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Category Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableCat" title="Copy Category Performance Pivot table" aria-label="Copy Category Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableCat" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-left" id="pivotCustTypeCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Customer Search Term - TYPE Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableCustType" title="Copy Customer Search Term - TYPE Performance Pivot table" aria-label="Copy Customer Search Term - TYPE Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableCustType" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-right" id="pivotPlacementCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Placement Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTablePlacement" title="Copy Placement Performance Pivot table" aria-label="Copy Placement Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTablePlacement" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-right" id="pivotCampaignCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Campaign Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableCampaign" title="Copy Campaign Performance Pivot table" aria-label="Copy Campaign Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableCampaign" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-overall-right" id="pivotAdGroupCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Ad Group Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableAdGroup" title="Copy Ad Group Performance Pivot table" aria-label="Copy Ad Group Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableAdGroup" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-extra-card" id="advertisedProductsCard" hidden>
+    <div class="chart-title">
+      <span class="chart-title-text">Advertised Products</span>
+    </div>
+    <div class="pivot-body">
+      <div id="advertisedProductsEmpty" class="advertised-empty" hidden>No advertised products for the selected filters.</div>
+      <table id="advertisedProductsTable" class="advertised-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col">Advertised SKU</th>
+            <th scope="col">Advertised ASIN</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingAsinCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Targeting ASIN Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingAsin" title="Copy Targeting ASIN Performance Pivot table" aria-label="Copy Targeting ASIN Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableTargetingAsin" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingKeywordCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Keyword Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingKeyword" title="Copy Keyword Performance Pivot table" aria-label="Copy Keyword Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableTargetingKeyword" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingCatCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Targeting CAT Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingCat" title="Copy Targeting CAT Performance Pivot table" aria-label="Copy Targeting CAT Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableTargetingCat" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-conversion pivot-targeting-right" id="pivotConversionStCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Customer Search Term (ST) Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableConversionSt" title="Copy Customer Search Term (ST) Performance Pivot table" aria-label="Copy Customer Search Term (ST) Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableConversionSt" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card pivot-conversion pivot-targeting-right" id="pivotConversionAsinCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Customer Search Term (ASIN) Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableConversionAsin" title="Copy Customer Search Term (ASIN) Performance Pivot table" aria-label="Copy Customer Search Term (ASIN) Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+          <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+        </svg>
+      </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableConversionAsin" class="pivot-table"></table>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<!-- Pivot filter popup -->
+<div id="pivotFilterPopup" class="pivot-filter-popup" hidden aria-hidden="true" role="dialog" aria-label="Pivot filter" tabindex="-1">
+  <div class="pivot-filter-popup-head">
+    <span class="pivot-filter-popup-title" id="pivotFilterPopupTitle">Filter pivot</span>
+    <button type="button" class="pivot-filter-popup-close" id="pivotFilterPopupClose" aria-label="Close pivot filter">✕</button>
+  </div>
+  <div class="pivot-filter-search-row">
+    <label class="pivot-filter-select-all"><input type="checkbox" id="pivotFilterPopupSelectAll"/>Select all</label>
+    <input type="search" class="pivot-filter-search" id="pivotFilterPopupSearch" placeholder="Search values" aria-label="Search pivot values" autocomplete="off"/>
+  </div>
+  <div class="pivot-filter-options" id="pivotFilterPopupList"></div>
+  <div class="pivot-filter-empty" id="pivotFilterPopupEmpty" hidden>No matching values</div>
+  <div class="pivot-filter-footer">
+    <button type="button" class="pivot-filter-clear" id="pivotFilterPopupClear">Clear</button>
+  </div>
+</div>
+
+<!-- Filters Modal -->
+<div id="filtersModal" class="modal" aria-hidden="true" role="dialog" aria-label="Filters">
+  <div class="modal-card">
+    <div class="modal-head">
+      <h3>Filters</h3>
+      <button id="closeFilters" class="btn-outline" title="Close">✕</button>
+    </div>
+
+    <section class="filters" id="filtersSection" hidden>
+      <div class="filter" data-col-wrapper="category"><label data-col-label="category" data-default="Category">Category</label><div id="categoryMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="store"><label data-col-label="store" data-default="Store">Store</label><div id="storeMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="lo"><label data-col-label="lo" data-default="LO">LO</label><div id="loMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="ttype"><label data-col-label="ttype" data-default="Targeting Type">Targeting Type</label><div id="ttypeMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="tsub"><label data-col-label="tsub" data-default="Targeting Sub Type">Targeting Sub Type</label><div id="tsubMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="tsub2"><label data-col-label="tsub2" data-default="Targeting Sub Type2">Targeting Sub Type2</label><div id="tsub2MS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="targeting"><label data-col-label="targeting" data-default="Keyword">Keyword</label><div id="targetingMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="targetingAsin"><label data-col-label="targetingAsin" data-default="Targeting ASIN">Targeting ASIN</label><div id="targetingAsinMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="targetingCat"><label data-col-label="targetingCat" data-default="Targeting CAT">Targeting CAT</label><div id="targetingCatMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="customerType"><label data-col-label="customerType" data-default="Customer Search Term - TYPE">Customer Search Term - TYPE</label><div id="customerTypeMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="placement"><label data-col-label="placement" data-default="Placement">Placement</label><div id="placementMS" class="dd"></div></div>
+      <div class="filter grow" data-col-wrapper="campaign"><label data-col-label="campaign" data-default="Campaign Name">Campaign Name</label><div id="campaignMS" class="dd"></div></div>
+      <div class="filter grow" data-col-wrapper="adgroup"><label data-col-label="adgroup" data-default="Ad Group Name">Ad Group Name</label><div id="adgroupMS" class="dd"></div></div>
+      <div class="filter grow" data-col-wrapper="portfolio"><label data-col-label="portfolio" data-default="Portfolio Name">Portfolio Name</label><div id="portfolioMS" class="dd"></div></div>
+
+    </section>
+
+    <div class="modal-actions">
+      <button id="clearAll" class="btn-outline">Clear All</button>
+      <button id="cancelFilters" class="btn-outline">Cancel</button>
+      <button id="applyFilters" class="btn-primary">Apply</button>
+    </div>
+  </div>
+</div>
+
+<script>
+'use strict';
+
+let sqlLibPromise=null;
+let sqlReadyPromise=null;
+const LOADING_PROGRESS_MAX_UPDATES=60;
+
+function computeProgressStep(total){
+  const count=Number.isFinite(total)?Math.max(0,total):0;
+  if(!count) return 0;
+  return Math.max(200, Math.ceil(count/LOADING_PROGRESS_MAX_UPDATES));
+}
+
+function updateLoadingProgress(processed,total){
+  const node=(typeof el!=='undefined' && el?.statusProgress) || null;
+  if(!node) return;
+  const done=Number.isFinite(processed)?Math.max(0,Math.floor(processed)):0;
+  const count=Number.isFinite(total)?Math.max(0,Math.floor(total)):0;
+  if(!done && !count){
+    node.textContent='';
+    return;
+  }
+  if(count){
+    if(!done){
+      node.textContent=`Preparing ${count.toLocaleString()} rows…`;
+      return;
+    }
+    const clamped=Math.min(done,count);
+    const percent=count?Math.min(100,Math.round((clamped/count)*100)):0;
+    const suffix=percent?` (${percent.toLocaleString()}%)`:'';
+    node.textContent=`Processed ${clamped.toLocaleString()} of ${count.toLocaleString()} rows${suffix}…`;
+  }else{
+    node.textContent=`Processed ${done.toLocaleString()} rows…`;
+  }
+}
+
+async function yieldForHeavyWork(){
+  if(typeof scheduler!=='undefined' && typeof scheduler.yield==='function'){
+    try{
+      await scheduler.yield();
+      return;
+    }catch(_){
+      /* ignore */
+    }
+  }
+  await new Promise(resolve=>{
+    if(typeof requestIdleCallback==='function'){
+      requestIdleCallback(()=>resolve(),{timeout:48});
+    }else if(typeof requestAnimationFrame==='function'){
+      requestAnimationFrame(()=>resolve());
+    }else{
+      setTimeout(resolve,0);
+    }
+  });
+}
+function loadSqlLibrary(){
+  if(!sqlLibPromise){
+    const ensureInit=()=>{
+      if(typeof initSqlJs==='function'){
+        try{
+          return initSqlJs({ locateFile:(file)=>`https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.9.0/${file}` });
+        }catch(err){
+          return Promise.reject(err);
+        }
+      }
+      return null;
+    };
+
+    const direct=ensureInit();
+    if(direct){
+      sqlLibPromise=direct;
+    }else{
+      sqlLibPromise=new Promise((resolve,reject)=>{
+        const started=Date.now();
+        const timeout=8000;
+        const poll=()=>{
+          const ready=ensureInit();
+          if(ready){
+            ready.then(resolve,reject);
+            return;
+          }
+          if(Date.now()-started>timeout){
+            reject(new Error('SQL.js failed to load'));
+            return;
+          }
+          setTimeout(poll,50);
+        };
+        poll();
+      });
+    }
+  }
+  return sqlLibPromise;
+}
+function getSqlDb(){ return state.sql?.db || null; }
+function sqlQueryAll(sql, params=[]){
+  const db=getSqlDb();
+  if(!db) return [];
+  const stmt=db.prepare(sql);
+  try{
+    if(params && params.length) stmt.bind(params);
+    const rows=[];
+    while(stmt.step()) rows.push(stmt.getAsObject());
+    return rows;
+  }finally{
+    stmt.free();
+  }
+}
+function sqlRun(sql){ const db=getSqlDb(); if(db) db.exec(sql); }
+function combineWhere(conditions, extra){
+  const list=[...(conditions||[])];
+  if(extra){
+    if(Array.isArray(extra)) list.push(...extra);
+    else list.push(extra);
+  }
+  const filtered=list.filter(cond=>cond && cond.sql);
+  if(!filtered.length) return {sql:'',params:[]};
+  const sql='WHERE '+filtered.map(cond=>`(${cond.sql})`).join(' AND ');
+  const params=[];
+  filtered.forEach(cond=>{ if(Array.isArray(cond.params)) params.push(...cond.params); });
+  return {sql,params};
+}
+function sanitizeHeaderKey(value){
+  return String(value||'').toLowerCase().replace(/[^a-z0-9]+/g,'');
+}
+function findSqlInfoByTokens(tokens){
+  const cols=state.sql?.columns || [];
+  if(!cols.length) return null;
+  const searchTokens=(Array.isArray(tokens)?tokens:[]).map(sanitizeHeaderKey).filter(Boolean);
+  if(!searchTokens.length) return null;
+  for(const info of cols){
+    const key=sanitizeHeaderKey(info.normalized || info.header || info.sqlName);
+    if(searchTokens.includes(key)) return info;
+  }
+  for(const info of cols){
+    const key=sanitizeHeaderKey(info.normalized || info.header || info.sqlName);
+    if(searchTokens.some(token=>key.includes(token))) return info;
+  }
+  return null;
+}
+function buildSqlInCondition(info, values){
+  if(!info || !info.sqlName) return null;
+  const cleaned=Array.isArray(values)?values.map(v=>String(v??'').trim()).filter(Boolean):[];
+  if(!cleaned.length) return null;
+  const placeholders=cleaned.map(()=>'?').join(', ');
+  if(!placeholders) return null;
+  return {sql:`"${info.sqlName}" COLLATE NOCASE IN (${placeholders})`, params:cleaned};
+}
+function makeSqlColumnName(base,fallback,used){
+  let name=String(base||'').toLowerCase().replace(/[^a-z0-9]+/g,'_').replace(/^_+/, '');
+  if(!name) name=fallback;
+  if(/^[0-9]/.test(name)) name=`c_${name}`;
+  let candidate=name;
+  let counter=1;
+  while(used.has(candidate)) candidate=`${name}_${counter++}`;
+  used.add(candidate);
+  return candidate;
+}
+function getSqlColumn(normalizedKey){
+  if(!state.sql || !state.sql.columnMap) return null;
+  return state.sql.columnMap.get(normalizedKey||'') || null;
+}
+function getSqlInfoForStateKey(key){
+  const col=state.columns[key];
+  if(!col) return null;
+  const normalized=normalize(col.name);
+  return getSqlColumn(normalized);
+}
+
+const DEFAULT_CONVERSION_PAGE_SIZE=500;
+const MAX_CONVERSION_ROWS=(()=>{
+  const globalValue=(typeof window!=='undefined')?Number(window.MAX_CONVERSION_ROWS ?? window.CONVERSION_PAGE_SIZE):NaN;
+  if(Number.isFinite(globalValue)){
+    return globalValue>0?Math.floor(globalValue):0;
+  }
+  return DEFAULT_CONVERSION_PAGE_SIZE;
+})();
+
+function ensureConversionElements(){
+  const pivotSection=document.getElementById('pivotSection');
+  if(!pivotSection) return;
+
+  const createNav=(type)=>{
+    const nav=document.createElement('div');
+    nav.className='pivot-pagination';
+    nav.dataset.pivot=type;
+    const chunkLabel=(MAX_CONVERSION_ROWS && MAX_CONVERSION_ROWS>0)
+      ? `${MAX_CONVERSION_ROWS.toLocaleString()} rows`
+      : 'page';
+    const prev=document.createElement('button');
+    prev.type='button';
+    prev.className='pivot-nav-btn prev';
+    prev.setAttribute('aria-label',`Previous ${chunkLabel}`);
+    prev.textContent='‹';
+    prev.disabled=true;
+    const label=document.createElement('span');
+    label.className='pivot-nav-label';
+    label.textContent='—';
+    const next=document.createElement('button');
+    next.type='button';
+    next.className='pivot-nav-btn next';
+    next.setAttribute('aria-label',`Next ${chunkLabel}`);
+    next.textContent='›';
+    next.disabled=true;
+    nav.append(prev,label,next);
+    return nav;
+  };
+
+  const ensureHead=(card)=>{
+    if(!card) return null;
+    let head=card.querySelector('.pivot-card-head');
+    if(head) return head;
+    head=document.createElement('div');
+    head.className='pivot-card-head';
+    const titleNode=card.querySelector('.chart-title');
+    if(titleNode){
+      card.insertBefore(head,titleNode);
+      head.appendChild(titleNode);
+    }else{
+      const title=document.createElement('div');
+      title.className='chart-title';
+      head.appendChild(title);
+      card.insertBefore(head, card.firstChild||null);
+    }
+    return head;
+  };
+
+  const ensureCard=(cardId,title,tableId,type)=>{
+    let card=document.getElementById(cardId);
+    if(!card){
+      card=document.createElement('div');
+      card.id=cardId;
+      card.className='chart-card pivot-card pivot-conversion';
+      const head=document.createElement('div');
+      head.className='pivot-card-head';
+      const titleNode=document.createElement('div');
+      titleNode.className='chart-title';
+      titleNode.textContent=title;
+      head.appendChild(titleNode);
+      head.appendChild(createNav(type));
+      card.appendChild(head);
+      const body=document.createElement('div');
+      body.className='pivot-body';
+      const table=document.createElement('table');
+      table.id=tableId;
+      table.className='pivot-table';
+      body.appendChild(table);
+      card.appendChild(body);
+      pivotSection.appendChild(card);
+      return card;
+    }
+
+    const head=ensureHead(card);
+    if(head && !head.querySelector('.pivot-pagination')){
+      head.appendChild(createNav(type));
+    }
+    const titleNode=head?.querySelector('.chart-title') || card.querySelector('.chart-title');
+    if(titleNode) titleNode.textContent=title;
+    if(tableId && !card.querySelector(`#${tableId}`)){
+      let body=card.querySelector('.pivot-body');
+      if(!body){
+        body=document.createElement('div');
+        body.className='pivot-body';
+        card.appendChild(body);
+      }
+      const table=document.createElement('table');
+      table.id=tableId;
+      table.className='pivot-table';
+      body.appendChild(table);
+    }
+
+    enhancePivotTitle(card);
+    return card;
+  };
+
+  ensureCard('pivotConversionStCard','Customer Search Term (ST) Performance Pivot','pivotTableConversionSt','st');
+  ensureCard('pivotConversionAsinCard','Customer Search Term (ASIN) Performance Pivot','pivotTableConversionAsin','asin');
+}
+
+function createCopyIcon(){
+  const span=document.createElement('span');
+  span.className='pivot-action-icon pivot-copy-icon';
+  span.setAttribute('aria-hidden','true');
+  span.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true"><rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect><rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect></svg>';
+  return span;
+}
+function createPivotCopyButton(tableId,label){
+  const btn=document.createElement('button');
+  btn.type='button';
+  btn.className='pivot-action-btn pivot-copy-btn';
+  if(tableId) btn.dataset.copyTarget=tableId;
+  const labelText=label?`Copy ${label} table`:'Copy pivot table';
+  btn.title=labelText;
+  btn.setAttribute('aria-label', labelText);
+  btn.appendChild(createCopyIcon());
+  return btn;
+}
+const PIVOT_FILTER_ICON='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true"><path d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 .78 1.63L14 13.21V19a1 1 0 0 1-1.45.89l-3-1.5A1 1 0 0 1 9 17.5v-4.29L4.22 5.63A1 1 0 0 1 4 5z"/></svg>';
+const PIVOT_CLEAR_ICON='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true"><path d="M7.05 7.05a1 1 0 0 1 1.4 0L12 10.59l3.55-3.54a1 1 0 0 1 1.41 1.41L13.41 12l3.55 3.54a1 1 0 0 1-1.41 1.42L12 13.41l-3.55 3.55a1 1 0 0 1-1.41-1.42L10.59 12 7.05 8.46a1 1 0 0 1 0-1.41z"/></svg>';
+ensureConversionElements();
+
+function enhancePivotTitle(card){
+  if(!card) return;
+  const title=card.querySelector('.chart-title');
+  if(!title) return;
+
+  let text=title.querySelector('.chart-title-text');
+  if(!text){
+    const fallback=title.textContent.trim();
+    title.textContent='';
+    text=document.createElement('span');
+    text.className='chart-title-text';
+    text.textContent=fallback;
+    title.appendChild(text);
+  }
+
+  let actions=title.querySelector('.chart-title-actions');
+  if(!actions){
+    actions=document.createElement('div');
+    actions.className='chart-title-actions';
+    title.appendChild(actions);
+  }
+
+  const strayButtons=Array.from(title.querySelectorAll(':scope > .pivot-copy-btn, :scope > .pivot-action-btn'));
+  strayButtons.forEach(btn=>actions.appendChild(btn));
+
+  let filterBtn=actions.querySelector('.pivot-filter-btn');
+  if(!filterBtn){
+    filterBtn=document.createElement('button');
+    filterBtn.type='button';
+    filterBtn.className='pivot-action-btn pivot-filter-btn';
+    filterBtn.title='Filter pivot';
+    filterBtn.setAttribute('aria-label','Filter pivot');
+    filterBtn.innerHTML=`<span class="pivot-action-icon" aria-hidden="true">${PIVOT_FILTER_ICON}</span>`;
+    actions.appendChild(filterBtn);
+  }
+
+  let clearBtn=actions.querySelector('.pivot-clear-btn');
+  if(!clearBtn){
+    clearBtn=document.createElement('button');
+    clearBtn.type='button';
+    clearBtn.className='pivot-action-btn pivot-clear-btn';
+    clearBtn.hidden=true;
+    clearBtn.title='Clear pivot filter';
+    clearBtn.setAttribute('aria-label','Clear pivot filter');
+    clearBtn.innerHTML=`<span class="pivot-action-icon" aria-hidden="true">${PIVOT_CLEAR_ICON}</span>`;
+    actions.insertBefore(clearBtn, filterBtn);
+  }
+
+  let copyBtn=actions.querySelector('.pivot-copy-btn');
+  if(!copyBtn){
+    const tableId=card.querySelector('.pivot-table')?.id || '';
+    const label=text?.textContent?.trim() || 'pivot';
+    copyBtn=createPivotCopyButton(tableId, label);
+    actions.appendChild(copyBtn);
+  }else{
+    if(!copyBtn.classList.contains('pivot-action-btn')){
+      copyBtn.classList.add('pivot-action-btn');
+    }
+    actions.appendChild(copyBtn);
+  }
+}
+
+function assignPivotSlots(){
+  if(!el.pivot) return;
+  Object.entries(el.pivot).forEach(([slot,target])=>{
+    if(slot==='section') return;
+    const card=target?.card;
+    if(!card) return;
+    card.dataset.pivotSlot=slot;
+    enhancePivotTitle(card);
+  });
+}
+
+function findPivotTarget(card){
+  if(!card) return null;
+  const slot=card.dataset.pivotSlot;
+  if(slot && el.pivot?.[slot]?.card===card) return el.pivot[slot];
+  for(const value of Object.values(el.pivot||{})){
+    if(value?.card===card) return value;
+  }
+  return null;
+}
+
+function getPivotFilterState(slot, create=false){
+  if(!slot) return null;
+  if(!state.pivotFilters) state.pivotFilters={};
+  let entry=state.pivotFilters[slot];
+  if(!entry && create){
+    entry={months:new Set(), start:'', end:''};
+    state.pivotFilters[slot]=entry;
+  }
+  if(entry){
+    if(!(entry.months instanceof Set)){
+      entry.months=new Set(Array.isArray(entry.months)?entry.months.filter(Boolean):[]);
+    }
+    entry.start=entry.start||'';
+    entry.end=entry.end||'';
+  }
+  return entry||null;
+}
+
+function clearPivotFilterState(slot){
+  if(!slot || !state.pivotFilters || !state.pivotFilters[slot]) return false;
+  delete state.pivotFilters[slot];
+  return true;
+}
+
+function pivotDateFilterIsActive(entry){
+  if(!entry) return false;
+  const monthActive = entry.months instanceof Set ? entry.months.size>0 : Array.isArray(entry.months) && entry.months.length>0;
+  return monthActive || !!entry.start || !!entry.end;
+}
+
+function getPivotFilterContext(card){
+  if(!card) return null;
+  const target=findPivotTarget(card);
+  if(!target) return null;
+  const table=target.table || card.querySelector('.pivot-table');
+  const dimension=table?._pivotData?.dimension || target.dimension || null;
+  const slot=card.dataset.pivotSlot || table?._pivotSlot || '';
+  const stateKey=dimension?.stateKey || '';
+  const columnInfo=stateKey ? state.columns?.[stateKey] : null;
+  const label=columnInfo?.name || columnInfo?.header || '';
+  const displayName=table?._pivotData?.displayName || label || 'Pivot';
+  return {target, table, dimension, slot, label, displayName, card};
+}
+
+function getPivotFilterContextFromButton(button){
+  if(!button) return null;
+  const card=button.closest('.pivot-card');
+  if(!card) return null;
+  enhancePivotTitle(card);
+  const context=getPivotFilterContext(card);
+  if(context) return context;
+
+  const table=card.querySelector('.pivot-table');
+  const slot=card.dataset.pivotSlot || table?._pivotSlot || button.dataset.pivotSlot || '';
+  const label=card.querySelector('.chart-title-text')?.textContent?.replace(/\s*Performance Pivot$/i,'').trim() || 'Pivot';
+  return {target:null, card, table, dimension:table?._pivotData?.dimension||null, slot, label, displayName:label};
+}
+
+function updatePivotFilterButtons(){
+  if(!el.pivot) return;
+  Object.entries(el.pivot).forEach(([slot,target])=>{
+    if(slot==='section') return;
+    const card=target?.card;
+    if(!card) return;
+    enhancePivotTitle(card);
+    const context=getPivotFilterContext(card);
+    if(!context) return;
+    const {table,label,displayName}=context;
+    const filterState=getPivotFilterState(context.slot || slot, false);
+    const hasActive=pivotDateFilterIsActive(filterState);
+    const filterLabel=(displayName || label || 'pivot');
+    const allowFilter=(state.monthOptions?.length||0)>0;
+    const filterBtn=card.querySelector('.pivot-filter-btn');
+    if(filterBtn){
+      const title=allowFilter?`Filter ${filterLabel} by date`:'Date filters unavailable';
+      filterBtn.dataset.pivotSlot=allowFilter?(context.slot || slot || ''):'';
+      filterBtn.title=title;
+      filterBtn.setAttribute('aria-label', title);
+      filterBtn.disabled=!allowFilter;
+      filterBtn.classList.toggle('is-active', hasActive);
+    }
+    const clearBtn=card.querySelector('.pivot-clear-btn');
+    if(clearBtn){
+      const clearTitle=`Clear ${filterLabel} date filter`;
+      clearBtn.dataset.pivotSlot=allowFilter?(context.slot || slot || ''):'';
+      clearBtn.title=clearTitle;
+      clearBtn.setAttribute('aria-label', clearTitle);
+      clearBtn.hidden=!hasActive;
+      clearBtn.disabled=!hasActive;
+    }
+    const copyBtn=card.querySelector('.pivot-copy-btn');
+    if(copyBtn){
+      if(!copyBtn.classList.contains('pivot-action-btn')) copyBtn.classList.add('pivot-action-btn');
+      const name=displayName || filterLabel || 'pivot';
+      const copyTitle=`Copy ${name} table`;
+      copyBtn.title=copyTitle;
+      copyBtn.setAttribute('aria-label', copyTitle);
+      if(table?.id) copyBtn.dataset.copyTarget=table.id;
+    }
+    card.dataset.pivotFilterActive = hasActive ? 'true' : 'false';
+  });
+}
+
+function pivotMakeValueKeys(rawValue, matchKey, dimension){
+  const raw=rawValue==null?'':String(rawValue);
+  const normalized=dimension?.caseInsensitive
+    ? (matchKey!=null && matchKey!=='' ? String(matchKey) : raw.toLocaleLowerCase())
+    : raw;
+  return {raw, normalized};
+}
+
+function getPivotSlotForTable(table){
+  if(!table) return '';
+  if(table._pivotSlot) return table._pivotSlot;
+  const card=table.closest?.('.pivot-card');
+  if(card) return card.dataset.pivotSlot || '';
+  return '';
+}
+
+function getPivotDimensionForTable(table){
+  if(!table) return null;
+  if(table._pivotData?.dimension) return table._pivotData.dimension;
+  const card=table.closest?.('.pivot-card');
+  if(!card) return null;
+  const context=getPivotFilterContext(card);
+  return context?.dimension || null;
+}
+
+function getPivotFilterValues(slot){
+  const entry=getPivotFilterState(slot, false);
+  if(!pivotDateFilterIsActive(entry)) return null;
+  const months = entry?.months instanceof Set ? Array.from(entry.months) : Array.isArray(entry?.months) ? entry.months.slice() : [];
+  const start = entry?.start || '';
+  const end = entry?.end || '';
+  return {
+    months: months.filter(v=>v!=null && v!==''),
+    start,
+    end
+  };
+}
+
+function appendDateFilterExtras(extras, filter){
+  if(!filter) return;
+  const dateInfo=getSqlInfoForStateKey('date');
+  if(!dateInfo) return;
+  const months=Array.isArray(filter.months)?filter.months.filter(v=>v!=null && v!==''):[];
+  if(months.length){
+    extras.push({sql:`substr("${dateInfo.sqlName}",1,7) IN (${months.map(()=>'?').join(',')})`, params:months});
+  }
+  if(filter.start){
+    extras.push({sql:`"${dateInfo.sqlName}" >= ?`, params:[filter.start]});
+  }
+  if(filter.end){
+    extras.push({sql:`"${dateInfo.sqlName}" <= ?`, params:[filter.end]});
+  }
+}
+
+function prunePivotFilter(){
+  /* no-op for date filters */
+}
+
+function updatePivotFilterSelection(){
+  return false;
+}
+
+function buildPivotPopupOptions(context){
+  const data=context.table?._pivotData ?? null;
+  if(!data) return [];
+  const rows=Array.isArray(data.allRows) && data.allRows.length ? data.allRows : (Array.isArray(data.rows)?data.rows:[]);
+  const dimension=context.dimension || null;
+  return rows.map(row=>{
+    const source=Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : row?.label;
+    const keys=pivotMakeValueKeys(source, row?.matchKey, dimension);
+    const labelStr=String(row?.label ?? keys.raw ?? '');
+    return {
+      label:labelStr,
+      labelLower:labelStr.toLocaleLowerCase(),
+      raw:keys.raw,
+      match:keys.normalized,
+      spend:Number(row?.spend)||0,
+      sales:Number(row?.sales)||0
+    };
+  }).filter(opt=>opt.raw);
+}
+
+function populatePivotFilterPopup(context, keepSearch){
+  pivotFilterPopupState.displayName=context.displayName || context.label || 'Pivot';
+  if(pivotFilterPopupState.mode==='date'){
+    if(!keepSearch) pivotFilterPopupState.search='';
+    if(el.pivotPopup?.title){
+      el.pivotPopup.title.textContent=`Filter ${pivotFilterPopupState.displayName} by date`;
+    }
+    const activeTab=pivotFilterPopupState.dateTab==='custom'?'custom':'months';
+    const searchRow=el.pivotPopup?.search?.closest('.pivot-filter-search-row');
+    if(searchRow) searchRow.hidden=activeTab==='custom';
+    if(el.pivotPopup?.search){
+      el.pivotPopup.search.value=pivotFilterPopupState.search;
+      el.pivotPopup.search.placeholder='Search months';
+      el.pivotPopup.search.removeAttribute('hidden');
+    }
+    renderPivotFilterPopup();
+    return;
+  }
+  pivotFilterPopupState.options=buildPivotPopupOptions(context);
+  if(!keepSearch) pivotFilterPopupState.search='';
+  if(el.pivotPopup?.title){
+    el.pivotPopup.title.textContent=`Filter ${pivotFilterPopupState.displayName}`;
+  }
+  if(el.pivotPopup?.search){
+    el.pivotPopup.search.value=pivotFilterPopupState.search;
+    el.pivotPopup.search.removeAttribute('hidden');
+  }
+  applyPivotPopupFilter(pivotFilterPopupState.search);
+}
+
+function applyPivotPopupFilter(query){
+  const value=String(query||'');
+  pivotFilterPopupState.search=value;
+  if(pivotFilterPopupState.mode==='date'){
+    renderPivotFilterPopup();
+    return;
+  }
+  const q=value.trim().toLocaleLowerCase();
+  const list=pivotFilterPopupState.options||[];
+  pivotFilterPopupState.filtered = q ? list.filter(opt=>opt.labelLower.includes(q) || opt.raw.toLocaleLowerCase().includes(q)) : list.slice();
+  renderPivotFilterPopup();
+}
+
+function renderPivotFilterPopup(){
+  const listEl=el.pivotPopup?.list;
+  const emptyEl=el.pivotPopup?.empty;
+  if(!listEl) return;
+  if(pivotFilterPopupState.mode==='date'){
+    renderPivotDatePopup();
+    return;
+  }
+  listEl.innerHTML='';
+  const filtered=pivotFilterPopupState.filtered||[];
+  const dimension=pivotFilterPopupState.dimension;
+  const slot=pivotFilterPopupState.slot;
+  const entry=getPivotFilterState(slot, false);
+  if(!filtered.length){
+    if(emptyEl) emptyEl.hidden=false;
+    updatePivotPopupSelectAllState();
+    return;
+  }
+  if(emptyEl) emptyEl.hidden=true;
+  const frag=document.createDocumentFragment();
+  filtered.forEach(opt=>{
+    const row=document.createElement('label');
+    row.className='pivot-filter-option';
+    const left=document.createElement('span');
+    left.className='pivot-filter-option-label';
+    const input=document.createElement('input');
+    input.type='checkbox';
+    input.dataset.rawValue=opt.raw;
+    input.dataset.matchKey=opt.match;
+    const isSelected=entry? (dimension?.caseInsensitive ? entry.match.has(opt.match) : entry.raw.has(opt.raw)) : false;
+    input.checked=isSelected;
+    left.appendChild(input);
+    const valueSpan=document.createElement('span');
+    valueSpan.className='pivot-filter-option-value';
+    valueSpan.textContent=opt.label || opt.raw || '—';
+    left.appendChild(valueSpan);
+    row.appendChild(left);
+    const metric=document.createElement('span');
+    metric.className='pivot-filter-option-metric';
+    metric.textContent=fmt.money0(opt.spend);
+    row.appendChild(metric);
+    frag.appendChild(row);
+  });
+  listEl.appendChild(frag);
+  updatePivotPopupSelectAllState();
+}
+
+function renderPivotDatePopup(){
+  const listEl=el.pivotPopup?.list;
+  const emptyEl=el.pivotPopup?.empty;
+  if(!listEl) return;
+  const activeTab=pivotFilterPopupState.dateTab==='custom'?'custom':'months';
+  const searchRow=el.pivotPopup?.search?.closest('.pivot-filter-search-row');
+  if(searchRow) searchRow.hidden=activeTab==='custom';
+  const months=state.monthOptions||[];
+  const query=(pivotFilterPopupState.search||'').trim().toLocaleLowerCase();
+  const filtered=query
+    ? months.filter(opt=>{
+        const label=String(opt?.label||'').toLocaleLowerCase();
+        const ym=String(opt?.ym||'').toLocaleLowerCase();
+        return label.includes(query) || ym.includes(query);
+      })
+    : months.slice();
+  pivotFilterPopupState.filtered=filtered;
+  listEl.innerHTML='';
+
+  const tabs=document.createElement('div');
+  tabs.className='pivot-date-tabs';
+  const makeTab=(tab,value)=>{
+    const btn=document.createElement('button');
+    btn.type='button';
+    btn.className=`pivot-date-tab${activeTab===tab?' is-active':''}`;
+    btn.dataset.tab=tab;
+    btn.textContent=value;
+    btn.addEventListener('click', handlePivotDateTabClick);
+    return btn;
+  };
+  tabs.appendChild(makeTab('months','Months'));
+  tabs.appendChild(makeTab('custom','Custom'));
+  listEl.appendChild(tabs);
+
+  const entry=getPivotFilterState(pivotFilterPopupState.slot, false);
+  const monthSet=entry?.months instanceof Set ? entry.months : new Set();
+
+  if(activeTab==='months'){
+    if(filtered.length){
+      if(emptyEl) emptyEl.hidden=true;
+      const yearGroups=new Map();
+      filtered.forEach(opt=>{
+        if(!opt || !opt.year) return;
+        if(!yearGroups.has(opt.year)) yearGroups.set(opt.year, []);
+        yearGroups.get(opt.year).push(opt);
+      });
+      const frag=document.createDocumentFragment();
+      Array.from(yearGroups.entries()).forEach(([year, months])=>{
+        months.sort((a,b)=>a.monthIndex-b.monthIndex);
+        const group=document.createElement('div');
+        group.className='month-year-group';
+        group.dataset.year=year;
+        const row=document.createElement('div');
+        row.className='month-year-row';
+        const toggle=document.createElement('button');
+        toggle.type='button';
+        toggle.className='month-year-toggle';
+        toggle.setAttribute('aria-expanded','false');
+        toggle.setAttribute('aria-label',`Show ${year} months`);
+        toggle.textContent='+';
+        row.appendChild(toggle);
+        const label=document.createElement('span');
+        label.className='month-year-label';
+        label.textContent=year;
+        row.appendChild(label);
+        group.appendChild(row);
+        const monthsWrap=document.createElement('div');
+        monthsWrap.className='month-year-months';
+        monthsWrap.dataset.yearMonths=year;
+        monthsWrap.hidden=true;
+        months.forEach(opt=>{
+          const monthRow=document.createElement('label');
+          monthRow.className='month-row';
+          const input=document.createElement('input');
+          input.type='checkbox';
+          input.dataset.month=opt.ym;
+          input.checked=monthSet.has(opt.ym);
+          monthRow.appendChild(input);
+          const name=document.createElement('span');
+          name.className='month-name';
+          name.textContent=opt.label || opt.ym || '—';
+          monthRow.appendChild(name);
+          monthsWrap.appendChild(monthRow);
+        });
+        group.appendChild(monthsWrap);
+        frag.appendChild(group);
+      });
+      listEl.appendChild(frag);
+      listEl.querySelectorAll('.month-year-toggle').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          const group=btn.closest('.month-year-group');
+          if(!group) return;
+          const year=group.getAttribute('data-year');
+          const currentPanel=group.querySelector('.month-year-months');
+          const willOpen=!!currentPanel?.hidden;
+          listEl.querySelectorAll('.month-year-months').forEach(panel=>{
+            const isTarget=panel.getAttribute('data-year-months')===year;
+            panel.hidden=!(isTarget && willOpen);
+          });
+          listEl.querySelectorAll('.month-year-toggle').forEach(toggle=>{
+            const toggleGroup=toggle.closest('.month-year-group');
+            const isOpen=willOpen && toggleGroup?.getAttribute('data-year')===year;
+            toggle.classList.toggle('is-open', isOpen);
+            toggle.textContent=isOpen ? '-' : '+';
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            const labelYear=toggleGroup?.getAttribute('data-year') || year;
+            toggle.setAttribute('aria-label', `${isOpen ? 'Hide' : 'Show'} ${labelYear} months`);
+          });
+        });
+      });
+    }else if(emptyEl){
+      emptyEl.hidden=false;
+      emptyEl.textContent=months.length ? 'No matching months' : 'No month data';
+    }
+  }else{
+    if(emptyEl){
+      emptyEl.hidden=true;
+      emptyEl.textContent='';
+    }
+    const range=document.createElement('div');
+    range.className='pivot-date-range';
+    range.innerHTML=`<h4>Custom range</h4><div class="pivot-date-range-fields"><label><span>From</span><input type="date" data-role="pivot-date-start"></label><label><span>To</span><input type="date" data-role="pivot-date-end"></label></div><div class="pivot-date-range-note">Pick a start and end date to refine this pivot.</div>`;
+    listEl.appendChild(range);
+
+    const startInput=range.querySelector('input[data-role="pivot-date-start"]');
+    const endInput=range.querySelector('input[data-role="pivot-date-end"]');
+    const bounds=state.dateBounds || {};
+    const minStr=bounds.min?toInputDate(bounds.min):'';
+    const maxStr=bounds.max?toInputDate(bounds.max):'';
+    if(startInput){
+      if(minStr) startInput.min=minStr; else startInput.removeAttribute('min');
+      if(maxStr) startInput.max=maxStr; else startInput.removeAttribute('max');
+      startInput.value=entry?.start||'';
+      startInput.addEventListener('change', handlePivotDateRangeInput);
+    }
+    if(endInput){
+      if(minStr) endInput.min=minStr; else endInput.removeAttribute('min');
+      if(maxStr) endInput.max=maxStr; else endInput.removeAttribute('max');
+      endInput.value=entry?.end||'';
+      endInput.addEventListener('change', handlePivotDateRangeInput);
+    }
+  }
+
+  updatePivotPopupSelectAllState();
+}
+
+function handlePivotDateTabClick(event){
+  const button=event.target.closest?.('button[data-tab]');
+  if(!button) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const tab=button.dataset.tab==='custom'?'custom':'months';
+  if(tab===pivotFilterPopupState.dateTab) return;
+  pivotFilterPopupState.dateTab=tab;
+  const searchRow=el.pivotPopup?.search?.closest('.pivot-filter-search-row');
+  if(searchRow) searchRow.hidden=tab==='custom';
+  renderPivotDatePopup();
+  updatePivotPopupSelectAllState();
+  if(tab==='months' && el.pivotPopup?.search){
+    try{ el.pivotPopup.search.focus({preventScroll:true}); }catch(_){ }
+  }
+}
+
+function handlePivotDateRangeInput(){
+  const slot=pivotFilterPopupState.slot;
+  if(!slot) return;
+  const entry=getPivotFilterState(slot, true);
+  const popup=el.pivotPopup?.root;
+  if(!popup) return;
+  const startField=popup.querySelector('input[data-role="pivot-date-start"]');
+  const endField=popup.querySelector('input[data-role="pivot-date-end"]');
+  const prevStart=entry.start||'';
+  const prevEnd=entry.end||'';
+  const nextStart=startField?String(startField.value||'').trim():'';
+  const nextEnd=endField?String(endField.value||'').trim():'';
+  if(nextStart && nextEnd && nextStart>nextEnd){
+    alert('Start date must be on or before end date.');
+    if(startField) startField.value=prevStart;
+    if(endField) endField.value=prevEnd;
+    return;
+  }
+  entry.start=nextStart;
+  entry.end=nextEnd;
+  if(!pivotDateFilterIsActive(entry)){
+    clearPivotFilterState(slot);
+  }
+  renderAll();
+  updatePivotFilterButtons();
+  updatePivotPopupSelectAllState();
+}
+
+function updatePivotPopupSelectAllState(){
+  const toggle=el.pivotPopup?.selectAll;
+  if(!toggle) return;
+  if(pivotFilterPopupState.mode==='date'){
+    const searchRow=toggle.closest?.('.pivot-filter-search-row');
+    const isMonths=pivotFilterPopupState.dateTab!=='custom';
+    if(searchRow) searchRow.hidden=!isMonths;
+    if(!isMonths){
+      toggle.checked=false;
+      toggle.indeterminate=false;
+      toggle.disabled=true;
+      return;
+    }
+    const filtered=pivotFilterPopupState.filtered||[];
+    const slot=pivotFilterPopupState.slot;
+    const entry=getPivotFilterState(slot, false);
+    const monthSet=entry?.months instanceof Set ? entry.months : new Set();
+    if(!filtered.length){
+      toggle.checked=false;
+      toggle.indeterminate=false;
+      toggle.disabled=true;
+      return;
+    }
+    let selectedCount=0;
+    filtered.forEach(opt=>{ if(monthSet.has(opt.ym)) selectedCount++; });
+    toggle.disabled=false;
+    toggle.checked = selectedCount>0 && selectedCount===filtered.length;
+    toggle.indeterminate = selectedCount>0 && selectedCount<filtered.length;
+    return;
+  }
+  const filtered=pivotFilterPopupState.filtered||[];
+  const dimension=pivotFilterPopupState.dimension;
+  const slot=pivotFilterPopupState.slot;
+  const entry=getPivotFilterState(slot, false);
+  if(!filtered.length){
+    toggle.checked=false;
+    toggle.indeterminate=false;
+    return;
+  }
+  let selectedCount=0;
+  if(entry){
+    filtered.forEach(opt=>{
+      const selected=dimension?.caseInsensitive ? entry.match.has(opt.match) : entry.raw.has(opt.raw);
+      if(selected) selectedCount++;
+    });
+  }
+  toggle.checked = selectedCount>0 && selectedCount===filtered.length;
+  toggle.indeterminate = selectedCount>0 && selectedCount<filtered.length;
+}
+
+function positionPivotPopupRoot(trigger){
+  const popup=el.pivotPopup?.root;
+  if(!popup) return;
+  const rect=trigger?.getBoundingClientRect?.();
+  const viewportWidth=window.innerWidth || document.documentElement.clientWidth || 0;
+  const viewportHeight=window.innerHeight || document.documentElement.clientHeight || 0;
+  const width=popup.offsetWidth||0;
+  const height=popup.offsetHeight||0;
+  let left=rect?rect.left:((viewportWidth-width)/2);
+  let top=rect?(rect.bottom+8):((viewportHeight-height)/2);
+  if(left+width>viewportWidth-12) left=Math.max(12, viewportWidth-width-12);
+  if(top+height>viewportHeight-12){
+    top=Math.max(12, rect?rect.top-height-8:((viewportHeight-height)/2));
+  }
+  if(left<12) left=12;
+  if(top<12) top=12;
+  popup.style.left=`${Math.round(left)}px`;
+  popup.style.top=`${Math.round(top)}px`;
+}
+
+function showPivotDatePopup(context, trigger){
+  const popup=el.pivotPopup?.root;
+  if(!popup) return;
+  const slot=context.slot || '';
+  if(!slot) return;
+  pivotFilterPopupState.mode='date';
+  pivotFilterPopupState.slot=slot;
+  pivotFilterPopupState.dimension=null;
+  pivotFilterPopupState.button=trigger || null;
+  pivotFilterPopupState.search='';
+  pivotFilterPopupState.filtered=[];
+  pivotFilterPopupState.dateTab='months';
+  pivotFilterPopupState.displayName=context.displayName || context.label || 'Pivot';
+  state.activePivotPopup={slot, button:trigger||null};
+  populatePivotFilterPopup(context, false);
+  popup.hidden=false;
+  popup.setAttribute('aria-hidden','false');
+  popup.style.visibility='hidden';
+  popup.style.opacity='0';
+  popup.offsetWidth;
+  positionPivotPopupRoot(trigger);
+  popup.style.visibility='';
+  popup.style.opacity='';
+  requestAnimationFrame(()=>{
+    try{
+      if(el.pivotPopup?.search && !el.pivotPopup.search.hasAttribute('hidden')){
+        el.pivotPopup.search.focus({preventScroll:true});
+        el.pivotPopup.search.select();
+      }else{
+        popup.focus({preventScroll:true});
+      }
+    }catch(_){ }
+  });
+}
+
+function closePivotFilterPopup(focusReturn=true){
+  const popup=el.pivotPopup?.root;
+  if(!popup || popup.hasAttribute('hidden')) return false;
+  popup.hidden=true;
+  popup.setAttribute('aria-hidden','true');
+  const trigger=state.activePivotPopup?.button;
+  const shouldFocus=focusReturn && trigger && typeof trigger.focus==='function';
+  state.activePivotPopup=null;
+  pivotFilterPopupState.slot='';
+  pivotFilterPopupState.dimension=null;
+  pivotFilterPopupState.button=null;
+  pivotFilterPopupState.filtered=[];
+  pivotFilterPopupState.search='';
+  pivotFilterPopupState.mode='dimension';
+  pivotFilterPopupState.dateTab='months';
+  if(shouldFocus){
+    requestAnimationFrame(()=>{
+      try{ trigger.focus({preventScroll:true}); }catch(_){ }
+    });
+  }
+  return true;
+}
+
+function refreshActivePivotPopup(){
+  const active=state.activePivotPopup;
+  if(!active || !active.slot) return;
+  const target=el.pivot?.[active.slot];
+  const card=target?.card;
+  const table=target?.table || card?.querySelector('.pivot-table');
+  if(!card){
+    closePivotFilterPopup(false);
+    return;
+  }
+  const displayName = table?._pivotData?.displayName || card.querySelector('.chart-title-text')?.textContent || '';
+  const context={target, card, table, dimension:null, slot:active.slot, label:'', displayName};
+  pivotFilterPopupState.button = active.button && document.body.contains(active.button) ? active.button : card.querySelector('.pivot-filter-btn');
+  populatePivotFilterPopup(context, true);
+  const popup=el.pivotPopup?.root;
+  if(popup && !popup.hasAttribute('hidden')){
+    popup.style.visibility='hidden';
+    popup.offsetWidth;
+    positionPivotPopupRoot(pivotFilterPopupState.button || card);
+    popup.style.visibility='';
+  }
+}
+
+function handlePivotPopupSearchInput(){
+  if(!el.pivotPopup?.search) return;
+  applyPivotPopupFilter(el.pivotPopup.search.value || '');
+}
+
+function handlePivotPopupSelectAll(event){
+  const checked=!!event.target.checked;
+  const filtered=pivotFilterPopupState.filtered||[];
+  const slot=pivotFilterPopupState.slot;
+  if(!slot) return;
+  if(pivotFilterPopupState.mode==='date'){
+    if(pivotFilterPopupState.dateTab==='custom'){
+      updatePivotPopupSelectAllState();
+      return;
+    }
+    if(!filtered.length){
+      updatePivotPopupSelectAllState();
+      return;
+    }
+    const entry=checked ? getPivotFilterState(slot, true) : getPivotFilterState(slot, false);
+    if(entry){
+      if(!(entry.months instanceof Set)) entry.months=new Set();
+      filtered.forEach(opt=>{
+        if(checked) entry.months.add(opt.ym);
+        else entry.months.delete(opt.ym);
+      });
+      if(!pivotDateFilterIsActive(entry)) clearPivotFilterState(slot);
+    }
+    renderAll();
+    updatePivotFilterButtons();
+    renderPivotDatePopup();
+    return;
+  }
+  updatePivotPopupSelectAllState();
+}
+
+function handlePivotPopupListChange(event){
+  const input=event.target.closest?.('input[type=checkbox]');
+  if(!input) return;
+  const slot=pivotFilterPopupState.slot;
+  if(!slot) return;
+  if(pivotFilterPopupState.mode==='date'){
+    if(pivotFilterPopupState.dateTab==='custom'){
+      return;
+    }
+    const month=input.dataset.month || '';
+    if(!month){
+      updatePivotPopupSelectAllState();
+      return;
+    }
+    const entry=getPivotFilterState(slot, true);
+    if(input.checked) entry.months.add(month);
+    else{
+      entry.months.delete(month);
+      if(!pivotDateFilterIsActive(entry)) clearPivotFilterState(slot);
+    }
+    renderAll();
+    updatePivotFilterButtons();
+    updatePivotPopupSelectAllState();
+    return;
+  }
+  updatePivotPopupSelectAllState();
+}
+
+function getFilterWrapperByStateKey(stateKey){
+  if(!stateKey) return null;
+  const esc=(typeof CSS!=='undefined' && typeof CSS.escape==='function') ? CSS.escape(stateKey) : String(stateKey).replace(/["\\]/g,'\\$&');
+  return document.querySelector(`[data-col-wrapper="${esc}"]`);
+}
+
+function highlightFilterWrapper(wrapper){
+  if(!wrapper) return;
+  wrapper.classList.add('is-highlighted');
+  const existing=filterHighlightTimers.get(wrapper);
+  if(existing) clearTimeout(existing);
+  const timeout=setTimeout(()=>{
+    wrapper.classList.remove('is-highlighted');
+    filterHighlightTimers.delete(wrapper);
+  },1600);
+  filterHighlightTimers.set(wrapper, timeout);
+}
+
+function focusFilterControl(wrapper, options={}){
+  if(!wrapper) return;
+  const ddRoot=wrapper.querySelector('.dd');
+  if(!ddRoot) return;
+  const panel=ddRoot.querySelector('.dd-panel');
+  const openDropdown = options.openDropdown!==false;
+  document.querySelectorAll('.dd.open').forEach(node=>{
+    if(node!==ddRoot){
+      node.classList.remove('open');
+      const nodePanel=node.querySelector('.dd-panel');
+      if(nodePanel){
+        nodePanel.hidden=true;
+        nodePanel.setAttribute('hidden','');
+      }
+    }
+  });
+  if(openDropdown){
+    if(ddRoot.classList.contains('dd-search-mode')){
+      if(panel){
+        panel.hidden=false;
+        panel.removeAttribute('hidden');
+        clampPanelRight(panel);
+      }
+      ddRoot.classList.add('open');
+      const input=ddRoot.querySelector('.dd-search');
+      if(input){
+        try{ input.focus({preventScroll:true}); }catch(_){ try{ input.focus(); }catch(__){} }
+        if(typeof input.select==='function') input.select();
+      }
+      ddRefreshSearchSelections(ddRoot);
+    }else{
+      ddRoot.classList.add('open');
+      if(panel){
+        panel.hidden=false;
+        panel.removeAttribute('hidden');
+        clampPanelRight(panel);
+      }
+      const search=ddRoot.querySelector('.dd-search');
+      if(search){
+        try{ search.focus({preventScroll:true}); }catch(_){ try{ search.focus(); }catch(__){} }
+        if(typeof search.select==='function') search.select();
+      }
+    }
+    return;
+  }
+  ddRoot.classList.remove('open');
+  if(panel){
+    panel.hidden=true;
+    if(typeof panel.setAttribute==='function') panel.setAttribute('hidden','');
+  }
+  const preferred = ddRoot.classList.contains('dd-search-mode')
+    ? ddRoot.querySelector('.dd-search')
+    : ddRoot.querySelector('.dd-control');
+  const focusTarget = preferred || wrapper.querySelector('[data-col-label]') || el.applyFiltersBtn;
+  if(!focusTarget || typeof focusTarget.focus!=='function') return;
+  const prevTabIndex = focusTarget.getAttribute?.('tabindex');
+  if(focusTarget.tabIndex<0){
+    focusTarget.setAttribute('tabindex','-1');
+  }
+  try{ focusTarget.focus({preventScroll:true}); }
+  catch(_){ try{ focusTarget.focus(); }catch(__){} }
+  if(focusTarget){
+    const cleanup=()=>{
+      if(prevTabIndex===null || prevTabIndex===undefined) focusTarget.removeAttribute('tabindex');
+      else focusTarget.setAttribute('tabindex', prevTabIndex);
+    };
+    focusTarget.addEventListener('blur', cleanup, {once:true});
+  }
+}
+
+function applyPivotModalSelection(context){
+  return false;
+}
+
+function showMainFilterForStateKey(stateKey, trigger, options={}){
+  if(!stateKey || !el.modal) return false;
+  const wrapper=getFilterWrapperByStateKey(stateKey);
+  if(!wrapper || wrapper.hidden) return false;
+  if(trigger) state.filtersReturn=trigger;
+  const fromPivot=!!options.fromPivot;
+  if(!el.modal.classList.contains('open')){
+    openFiltersModal({fromPivot});
+  }
+  requestAnimationFrame(()=>{
+    try{ wrapper.scrollIntoView({behavior:'smooth', block:'nearest'}); }
+    catch(_){ try{ wrapper.scrollIntoView({block:'nearest'}); }catch(__){} }
+    highlightFilterWrapper(wrapper);
+    const autoOpen = options.autoOpenDropdown!==false;
+    focusFilterControl(wrapper, {openDropdown:autoOpen});
+  });
+  return true;
+}
+
+function handlePivotFilterButton(button){
+  const context=getPivotFilterContextFromButton(button);
+  if(!context) return;
+  state.activePivotModal=null;
+  const slot=context.slot || button.dataset.pivotSlot || '';
+  if(!slot) return;
+  const popup=el.pivotPopup?.root;
+  if(popup && !popup.hasAttribute('hidden') && state.activePivotPopup?.slot===slot && pivotFilterPopupState.mode==='date'){
+    closePivotFilterPopup();
+    return;
+  }
+  showPivotDatePopup(context, button);
+  button.classList.add('is-active');
+  setTimeout(()=>button.classList.remove('is-active'),220);
+}
+
+function handlePivotClearButton(button){
+  const context=getPivotFilterContextFromButton(button);
+  if(!context) return;
+  const slot=context.slot || button.dataset.pivotSlot || '';
+  if(!slot) return;
+  const changed=clearPivotFilterState(slot);
+  closePivotFilterPopup(false);
+  if(changed){
+    renderAll();
+  }else{
+    updatePivotFilterButtons();
+  }
+}
+
+/* ===== helpers ===== */
+const fmt={
+  int:n=>isFinite(n)?n.toLocaleString():"—",
+  compact:n=>isFinite(n)?new Intl.NumberFormat(undefined,{notation:'compact',maximumFractionDigits:1}).format(n):"—",
+  pct:r=>isFinite(r)?(r*100).toLocaleString(undefined,{maximumFractionDigits:2})+'%':"—",
+  money:n=>isFinite(n)?n.toLocaleString(undefined,{style:"currency",currency:"USD"}):"—",
+  money0:n=>isFinite(n)?n.toLocaleString(undefined,{style:"currency",currency:"USD",maximumFractionDigits:0,minimumFractionDigits:0}):"—",
+  num0:n=>isFinite(n)?new Intl.NumberFormat(undefined,{maximumFractionDigits:0,minimumFractionDigits:0}).format(n):"—"
+};
+const MONTH_NAMES=["January","February","March","April","May","June","July","August","September","October","November","December"];
+const LAST_PUSH_DATE="2025-12-26 08:37:47 +0000";
+const normalize=s=>String(s||"").trim().toLowerCase().replace(/\s+/g," ");
+function normalizeAdvertisedKey(value){
+  if(value==null) return '';
+  let str=String(value).toLowerCase();
+  str=str.trim();
+  str=str.replace(/[\u2010-\u2015\u2212\uFE58\uFE63\uFF0D]/g,'-');
+  str=str.replace(/\s+/g,' ');
+  str=str.replace(/\s*-\s*/g,'-');
+  return str.trim();
+}
+const escapeHtml=s=>String(s).replace(/[&<>\"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+const debounce=(fn,ms=150)=>{let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),ms);};};
+const toDMY=d=>!(d instanceof Date)?"":`${String(d.getDate()).padStart(2,'0')} ${MONTH_NAMES[d.getMonth()]||''} ${d.getFullYear()}`.trim();
+const parseDMY=(s)=>{ if(!s) return null; const m=String(s).match(/^(\d{2})[-/](\d{2})[-/](\d{4})$/); if(!m) return null; const d=new Date(+m[3], +m[2]-1, +m[1]); return isNaN(+d)?null:d; };
+const toInputDate=d=>!(d instanceof Date)?"":`${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+const parseInputDate=s=>{ if(!s) return null; const m=String(s).match(/^(\d{4})-(\d{2})-(\d{2})$/); if(!m) return null; const d=new Date(+m[1], +m[2]-1, +m[3]); return isNaN(+d)?null:d; };
+const parseAnyDate=value=>{ if(value instanceof Date) return value; if(!value) return null; const trimmed=String(value).trim(); return parseInputDate(trimmed) || parseDMY(trimmed) || (isNaN(+new Date(trimmed))?null:new Date(trimmed)); };
+const formatDisplayDate=value=>{ const d=parseAnyDate(value); return d?toDMY(d):'—'; };
+const cloneDate=d=> (d instanceof Date) ? new Date(d.getTime()) : null;
+function parseNumber(v){
+  if(v==null || v==="") return 0;
+  if(typeof v==='number' && isFinite(v)) return v;
+  let s=String(v).trim();
+  if(!s) return 0;
+  const currencyCodePattern=/^(?:USD|CAD|AUD|NZD|EUR|GBP|INR|JPY|CNY|RMB|HKD|SGD|CHF|SEK|NOK|DKK|ZAR|MXN|BRL|AED|SAR|QAR|OMR|KWD|US|CA|AU|NZ|HK|SG|CN)\s*/i;
+  if(currencyCodePattern.test(s)){
+    s=s.replace(currencyCodePattern,"");
+  }
+  s=s.replace(/(?:USD|CAD|AUD|NZD|EUR|GBP|INR|JPY|CNY|RMB|HKD|SGD|CHF|SEK|NOK|DKK|ZAR|MXN|BRL|AED|SAR|QAR|OMR|KWD|US|CA|AU|NZ|HK|SG|CN)\s*$/i,"");
+  s=s.replace(/(?:USD|CAD|AUD|NZD|EUR|GBP|INR|JPY|CNY|RMB|HKD|SGD|CHF|SEK|NOK|DKK|ZAR|MXN|BRL|AED|SAR|QAR|OMR|KWD|US|CA|AU|NZ|HK|SG|CN)\$/gi,"$");
+  let negative=false;
+  if(/^\(.*\)$/.test(s)){
+    s=s.slice(1,-1);
+    negative=true;
+  }
+  let isPercent=false;
+  if(/%$/.test(s)){
+    isPercent=true;
+    s=s.replace(/%+$/,'');
+  }
+  s=s.replace(/[$€£₹¥₩]/g,'');
+  s=s.replace(/\s+/g,'');
+  s=s.replace(/,/g,'');
+  if(negative && !/^[-]/.test(s)){
+    s='-'+s;
+  }
+  let num=Number(s);
+  if(!Number.isFinite(num)){
+    const match=s.match(/[+\-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+\-]?\d+)?/);
+    num=match?Number(match[0]):NaN;
+  }
+  if(!Number.isFinite(num)) num=0;
+  if(isPercent) num/=100;
+  return num;
+}
+function clampPanelRight(panel){ panel.style.left='0'; panel.style.right='auto'; const rect=panel.getBoundingClientRect(), vw=document.documentElement.clientWidth; if(rect.right>vw-10){ panel.style.left='auto'; panel.style.right='0'; }}
+
+function hideCustomRangePanel(){
+  if(el.monthCustomPanel){
+    el.monthCustomPanel.setAttribute('hidden','');
+  }
+  if(state.monthTab==='custom' && !state.customRange.active){
+    state.monthTab='months';
+    updateMonthTabs();
+  }
+  updateMonthTabs();
+}
+
+function setMonthTab(tab){
+  const next=tab==='custom'?'custom':'months';
+  if(state.monthTab!==next){
+    state.monthTab=next;
+  }
+  updateMonthTabs();
+}
+
+function updateMonthTabs(){
+  const active=state.monthTab==='custom'?'custom':'months';
+  const buttons=el.monthTabList ? Array.from(el.monthTabList.querySelectorAll('button[data-tab]')) : [];
+  buttons.forEach(btn=>{
+    const tab=btn.dataset.tab==='custom'?'custom':'months';
+    const isActive=tab===active;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive?'true':'false');
+    btn.setAttribute('tabindex', isActive?'0':'-1');
+  });
+  if(el.monthList){
+    if(active==='months') el.monthList.removeAttribute('hidden');
+    else el.monthList.setAttribute('hidden','');
+  }
+  if(el.monthCustomPanel){
+    if(active==='custom'){
+      el.monthCustomPanel.removeAttribute('hidden');
+      syncCustomRangeInputs();
+    }else{
+      el.monthCustomPanel.setAttribute('hidden','');
+    }
+  }
+}
+function syncCustomRangeInputs(){
+  if(!el.monthCustomStart || !el.monthCustomEnd) return;
+  const {min,max}=state.dateBounds || {};
+  const minStr=toInputDate(min);
+  const maxStr=toInputDate(max);
+  if(minStr){
+    el.monthCustomStart.min=minStr; el.monthCustomEnd.min=minStr;
+  }else{
+    el.monthCustomStart.removeAttribute('min'); el.monthCustomEnd.removeAttribute('min');
+  }
+  if(maxStr){
+    el.monthCustomStart.max=maxStr; el.monthCustomEnd.max=maxStr;
+  }else{
+    el.monthCustomStart.removeAttribute('max'); el.monthCustomEnd.removeAttribute('max');
+  }
+  const startValue=state.customRange.start || min || null;
+  const endValue=state.customRange.end || max || null;
+  el.monthCustomStart.value=toInputDate(startValue);
+  el.monthCustomEnd.value=toInputDate(endValue);
+}
+function applyCustomRangeFromInputs(){
+  if(!state.hasData) return;
+  const start=parseInputDate(el.monthCustomStart?.value||'');
+  const end=parseInputDate(el.monthCustomEnd?.value||'');
+  if(!start || !end){
+    alert('Please select both start and end dates.');
+    return;
+  }
+  if(start>end){
+    alert('Start date must be on or before end date.');
+    return;
+  }
+  start.setHours(0,0,0,0);
+  end.setHours(0,0,0,0);
+  state.customRange={start,end,active:true};
+  state.monthSel.clear();
+  state.monthDirty=false;
+  el.monthList?.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
+  state.monthTab='custom';
+  updateMonthTabs();
+  if(el.monthDD) el.monthDD.classList.remove('open');
+  syncCustomRangeInputs();
+  updateMonthSummary();
+  if(state.hasData){
+    updateAllFilterOptions(null);
+    resetConversionPaging();
+    renderAll();
+  }
+  updateResetButtonVisibility();
+}
+function clearCustomRange(options={}){
+  const {skipRender=false, skipFilters=false}=options;
+  const hadActive = state.customRange.active || state.customRange.start || state.customRange.end;
+  state.customRange={start:null,end:null,active:false};
+  if(el.monthCustomStart) el.monthCustomStart.value='';
+  if(el.monthCustomEnd) el.monthCustomEnd.value='';
+  state.monthTab='months';
+  updateMonthTabs();
+  syncCustomRangeInputs();
+  updateMonthSummary();
+  updateResetButtonVisibility();
+  if(!hadActive) return;
+  resetConversionPaging();
+  if(state.hasData && !skipFilters) updateAllFilterOptions(null);
+  if(state.hasData && !skipRender) renderAll();
+}
+function deactivateCustomRange(){
+  if(!state.customRange.active) return;
+  state.customRange.active=false;
+  state.monthTab='months';
+  updateMonthTabs();
+  syncCustomRangeInputs();
+  updateMonthSummary();
+  updateResetButtonVisibility();
+}
+function handleMonthTabClick(event){
+  const button=event.target.closest?.('button[data-tab]');
+  if(!button) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const tab=button.dataset.tab==='custom'?'custom':'months';
+  setMonthTab(tab);
+  if(tab==='custom'){
+    try{ el.monthCustomStart?.focus({preventScroll:true}); }catch(_){ }
+  }
+}
+function handleCustomRangeCancel(){
+  syncCustomRangeInputs();
+  state.monthTab=state.customRange.active?'custom':'months';
+  updateMonthTabs();
+  if(el.monthDD) el.monthDD.classList.remove('open');
+  applyMonthFilters();
+}
+
+/* ===== elements/state ===== */
+const el={
+  datasetTitle:document.getElementById('datasetTitle'),
+  header:document.getElementById('appHeader'),
+  topLine:document.getElementById('topLine'),
+  tipPill:document.getElementById('tipPill'),
+  datasetMeta:document.getElementById('datasetMeta'),
+  dataTill:document.getElementById('dataTillValue'),
+  lastUpdated:document.getElementById('lastUpdatedValue'),
+  monthsWrap:document.getElementById('monthsWrap'),
+  monthDD:document.getElementById('monthFilter'),
+  monthList:document.getElementById('monthList'),
+  monthTabList:document.getElementById('monthTabList'),
+  monthCustomPanel:document.getElementById('customRangePanel'),
+  monthCustomStart:document.getElementById('customRangeStart'),
+  monthCustomEnd:document.getElementById('customRangeEnd'),
+  monthCustomApply:document.getElementById('customRangeApply'),
+  monthCustomCancel:document.getElementById('customRangeCancel'),
+  tabs:{
+    bar:document.getElementById('pivotTabsBar'),
+    list:document.getElementById('pivotTabs'),
+    buttons:[]
+  },
+  status:document.getElementById('statusArea'),
+  statusProgress:document.getElementById('statusProgress'),
+  kpis:document.getElementById('kpiSection'),
+  pivot:{
+    section:document.getElementById('pivotSection'),
+    store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},
+    lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},
+    cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')},
+    custType:{card:document.getElementById('pivotCustTypeCard'),table:document.getElementById('pivotTableCustType')},
+    placement:{card:document.getElementById('pivotPlacementCard'),table:document.getElementById('pivotTablePlacement')},
+    campaign:{card:document.getElementById('pivotCampaignCard'),table:document.getElementById('pivotTableCampaign')},
+    adGroup:{card:document.getElementById('pivotAdGroupCard'),table:document.getElementById('pivotTableAdGroup')},
+    portfolio:{card:document.getElementById('pivotPortfolioCard'),table:document.getElementById('pivotTablePortfolio')},
+    targetingAsin:{card:document.getElementById('pivotTargetingAsinCard'),table:document.getElementById('pivotTableTargetingAsin')},
+    targetingKeyword:{card:document.getElementById('pivotTargetingKeywordCard'),table:document.getElementById('pivotTableTargetingKeyword')},
+    targetingCat:{card:document.getElementById('pivotTargetingCatCard'),table:document.getElementById('pivotTableTargetingCat')},
+    conversionSt:{
+      card:document.getElementById('pivotConversionStCard'),
+      table:document.getElementById('pivotTableConversionSt'),
+      nav:document.querySelector('#pivotConversionStCard .pivot-pagination'),
+      navPrev:document.querySelector('#pivotConversionStCard .pivot-nav-btn.prev'),
+      navNext:document.querySelector('#pivotConversionStCard .pivot-nav-btn.next'),
+      navLabel:document.querySelector('#pivotConversionStCard .pivot-nav-label')
+    },
+    conversionAsin:{
+      card:document.getElementById('pivotConversionAsinCard'),
+      table:document.getElementById('pivotTableConversionAsin'),
+      nav:document.querySelector('#pivotConversionAsinCard .pivot-pagination'),
+      navPrev:document.querySelector('#pivotConversionAsinCard .pivot-nav-btn.prev'),
+      navNext:document.querySelector('#pivotConversionAsinCard .pivot-nav-btn.next'),
+      navLabel:document.querySelector('#pivotConversionAsinCard .pivot-nav-label')
+    }
+  },
+  advertisedProducts:{
+    card:document.getElementById('advertisedProductsCard'),
+    table:document.getElementById('advertisedProductsTable'),
+    body:document.querySelector('#advertisedProductsTable tbody'),
+    empty:document.getElementById('advertisedProductsEmpty')
+  },
+  pivotPopup:{
+    root:document.getElementById('pivotFilterPopup'),
+    title:document.getElementById('pivotFilterPopupTitle'),
+    close:document.getElementById('pivotFilterPopupClose'),
+    selectAll:document.getElementById('pivotFilterPopupSelectAll'),
+    search:document.getElementById('pivotFilterPopupSearch'),
+    list:document.getElementById('pivotFilterPopupList'),
+    empty:document.getElementById('pivotFilterPopupEmpty'),
+    clear:document.getElementById('pivotFilterPopupClear')
+  },
+  pickLocalBtn:document.getElementById('pickLocalBtn'),
+  fileInput:document.getElementById('fileInput'),
+  dlCsv:document.getElementById('downloadCsvBtn'),
+  openFiltersBtn:document.getElementById('openFilters'),
+  resetFiltersBtn:document.getElementById('resetFilters'),
+  datasetMenu:{
+    container:document.getElementById('datasetMenuContainer'),
+    btn:document.getElementById('datasetMenuBtn'),
+    popup:document.getElementById('datasetMenu'),
+    list:document.getElementById('datasetMenuList'),
+    current:document.getElementById('datasetMenuCurrent'),
+    empty:document.getElementById('datasetMenuEmpty')
+  },
+  modal:document.getElementById('filtersModal'),
+  closeFiltersBtn:document.getElementById('closeFilters'),
+  cancelFiltersBtn:document.getElementById('cancelFilters'),
+  applyFiltersBtn:document.getElementById('applyFilters'),
+  clearAllBtn:document.getElementById('clearAll'),
+  filters:document.getElementById('filtersSection'),
+  themeBtn:document.getElementById('themeBtn'),
+  empty:document.getElementById('emptyState'),
+  emptyDatasetOptions:document.getElementById('emptyDatasetOptions'),
+  emptyOpen:document.getElementById('emptyOpenBtn'),
+  kpi:{
+    spend:document.getElementById('kpiSpend'),
+    revenue:document.getElementById('kpiRevenue'),
+    acos:document.getElementById('kpiACOS'),
+    clicks:document.getElementById('kpiClicks'),
+    impr:document.getElementById('kpiImpr'),
+    ctr:document.getElementById('kpiCTR'),
+    roas:document.getElementById('kpiROAS'),
+    avgcpc:document.getElementById('kpiAvgCPC')
+  },
+  dd:{
+    category:document.getElementById('categoryMS'),
+    store:document.getElementById('storeMS'),
+    lo:document.getElementById('loMS'),
+    ttype:document.getElementById('ttypeMS'),
+    tsub:document.getElementById('tsubMS'),
+    tsub2:document.getElementById('tsub2MS'),
+    targeting:document.getElementById('targetingMS'),
+    targetingAsin:document.getElementById('targetingAsinMS'),
+    sku:document.getElementById('skuMS'),
+    targetingCat:document.getElementById('targetingCatMS'),
+    customerType:document.getElementById('customerTypeMS'),
+    placement:document.getElementById('placementMS'),
+    campaign:document.getElementById('campaignMS'),
+    adgroup:document.getElementById('adgroupMS'),
+    portfolio:document.getElementById('portfolioMS'),
+    term:document.getElementById('termMS')
+  }
+};
+const DEFAULT_HEADER_TITLE='Brands Campaign';
+const state={
+  rows:[],
+  columns:{},
+  monthSel:new Set(),
+  monthOptions:[],
+  monthDirty:false,
+  monthTab:'months',
+  snapshot:{},
+  hasData:false,
+  activeTab:'overview',
+  customRange:{start:null,end:null,active:false},
+  dateBounds:{min:null,max:null},
+  asinSkuMap:new Map(),
+  asinBrandMap:new Map(),
+  asinSkuLoaded:false,
+  asinValueMap:new Map(),
+  advertisedProducts:{rows:[],loaded:false,renderToken:0,lastSlot:null},
+  conversionPage:{st:0,asin:0},
+  lastTabIndex:0,
+  pivotFilters:{},
+  activePivotPopup:null,
+  activePivotModal:null,
+  filtersReturn:null,
+  sql:{db:null, table:'', columns:[], columnMap:new Map(), rowCount:0},
+  dataset:{type:'',file:'',label:''}
+};
+
+function updateDatasetTitle(){
+  const titleEl=el.datasetTitle;
+  if(!titleEl) return;
+  const dataset=state.dataset || {label:''};
+  const label=String(dataset.label||'').trim();
+  const text=label || DEFAULT_HEADER_TITLE;
+  titleEl.textContent=text;
+  try{
+    document.title=label?`${label} – ${DEFAULT_HEADER_TITLE}`:DEFAULT_HEADER_TITLE;
+  }catch(_){ }
+}
+
+function updateDatasetMeta(){
+  if(!el.datasetMeta || !el.dataTill || !el.lastUpdated) return;
+  const hasData=!!state.hasData;
+  el.dataTill.textContent=hasData?formatDisplayDate(state.dateBounds?.max):'—';
+  el.lastUpdated.textContent=formatDisplayDate(LAST_PUSH_DATE);
+  el.datasetMeta.hidden=!hasData;
+}
+
+function setActiveDataset(info){
+  if(!info){
+    state.dataset={type:'',file:'',label:''};
+  }else{
+    const file=info.file?String(info.file).trim():'';
+    const label=info.label || (file?formatDatasetLabelFromFile(file):'');
+    state.dataset={
+      type:info.type||'',
+      file,
+      label:label || file
+    };
+  }
+  applyDatasetOverrides(state.dataset);
+  updateDatasetMenuActive();
+  updateDatasetTitle();
+}
+
+function applyDatasetOverrides(dataset){
+  TAB_ORDER=DEFAULT_TAB_ORDER.slice();
+  PIVOT_CONFIG=clonePivotConfig(DEFAULT_PIVOT_CONFIG);
+  const file=(dataset?.file||'').toLowerCase();
+  const label=(dataset?.label||'').toLowerCase();
+  const isProductsCampaign=file.includes('products campaign') || label.includes('products campaign');
+  if(isProductsCampaign){
+    TAB_ORDER=TAB_ORDER.filter(tab=>tab!=='campaignPortfolio' && tab!=='targeting');
+    delete PIVOT_CONFIG.campaignPortfolio;
+    delete PIVOT_CONFIG.targeting;
+    const overall=PIVOT_CONFIG.overall||[];
+    const ensureSlot=(slot,column,fallback,options)=>{
+      if(!overall.some(entry=>entry?.slot===slot)){
+        const cfg={slot,column,fallback};
+        if(options) cfg.options={...options};
+        overall.push(cfg);
+      }
+    };
+    ensureSlot('campaign','campaign','Campaign Name');
+    ensureSlot('adGroup','adgroup','Ad Group Name');
+  }
+  updateTabButtonsForOrder(TAB_ORDER);
+  if(!TAB_ORDER.includes(state.activeTab)){
+    state.activeTab=TAB_ORDER[0] || 'overview';
+  }
+  state.lastTabIndex=TAB_ORDER.indexOf(state.activeTab);
+  updateTabsUI();
+  if(state.hasData) updateAdvertisedProductsDisplay();
+}
+
+function updateTabButtonsForOrder(order){
+  if(!el.tabs?.list) return;
+  const allowed=new Set(order||[]);
+  const buttons=Array.from(el.tabs.list.querySelectorAll('[data-tab]'));
+  buttons.forEach(btn=>{
+    const tab=btn.dataset.tab;
+    const show=allowed.size===0 || allowed.has(tab);
+    btn.hidden=!show;
+    if(!show){
+      btn.setAttribute('aria-hidden','true');
+      btn.setAttribute('tabindex','-1');
+      btn.setAttribute('aria-selected','false');
+      btn.classList.remove('is-active');
+    }else{
+      btn.removeAttribute('aria-hidden');
+    }
+  });
+  el.tabs.buttons=buttons.filter(btn=>!btn.hidden);
+  if(el.tabs.bar){
+    el.tabs.bar.hidden = el.tabs.buttons.length<=1;
+  }
+}
+
+function updateDatasetMenuActive(){
+  const dataset=state.dataset||{type:'',file:'',label:''};
+  const menu=el.datasetMenu||{};
+  if(menu.list){
+    menu.list.querySelectorAll('[data-dataset-id]').forEach(item=>{
+      const type=item.dataset.datasetType||'';
+      const file=item.dataset.datasetFile||'';
+      const isActive=!!dataset.file && dataset.type===type && dataset.file===file;
+      item.classList.toggle('is-active', isActive);
+      item.setAttribute('aria-checked', isActive?'true':'false');
+    });
+  }
+  if(el.emptyDatasetOptions){
+    el.emptyDatasetOptions.querySelectorAll('[data-dataset-id]').forEach(button=>{
+      const type=button.dataset.datasetType||'';
+      const file=button.dataset.datasetFile||'';
+      const isActive=!!dataset.file && dataset.type===type && dataset.file===file;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive?'true':'false');
+    });
+  }
+  if(menu.current){
+    menu.current.textContent = dataset.label ? `Current: ${dataset.label}` : 'No dataset loaded';
+  }
+  const base='Select dataset';
+  const suffix=dataset.label?` (current: ${dataset.label})`:'';
+  if(menu.btn){
+    const label=`${base}${suffix}`;
+    menu.btn.setAttribute('aria-label', label);
+    menu.btn.setAttribute('title', label);
+  }
+}
+
+function isDatasetMenuOpen(){
+  const popup=el.datasetMenu?.popup;
+  return !!(popup && !popup.hasAttribute('hidden'));
+}
+
+function openDatasetMenu(){
+  const menu=el.datasetMenu;
+  if(!menu?.popup) return false;
+  if(isDatasetMenuOpen()) return false;
+  menu.popup.classList.add('open');
+  menu.popup.removeAttribute('hidden');
+  if(menu.container) menu.container.classList.add('is-open');
+  if(menu.btn) menu.btn.setAttribute('aria-expanded','true');
+  clampPanelRight(menu.popup);
+  return true;
+}
+
+function closeDatasetMenu(focusBtn=true){
+  const menu=el.datasetMenu;
+  if(!menu?.popup) return false;
+  if(menu.popup.hasAttribute('hidden')) return false;
+  menu.popup.classList.remove('open');
+  menu.popup.setAttribute('hidden','');
+  if(menu.container) menu.container.classList.remove('is-open');
+  if(menu.btn){
+    menu.btn.setAttribute('aria-expanded','false');
+    if(focusBtn){
+      try{ menu.btn.focus({preventScroll:true}); }catch(_){ }
+    }
+  }
+  return true;
+}
+
+function toggleDatasetMenu(){
+  if(isDatasetMenuOpen()) closeDatasetMenu(false);
+  else openDatasetMenu();
+}
+
+async function handleDatasetSelection(type,file,label){
+  const datasetType=type||'';
+  const datasetFile=file||'';
+  const datasetLabel=label || formatDatasetLabelFromFile(datasetFile);
+  if(!datasetType || !datasetFile) return;
+  try{
+    showLoading(true);
+    if(datasetType==='workbook'){
+      await loadWorkbookDatasetFromUrl(datasetFile,datasetLabel);
+    }else if(datasetType==='preprocessed'){
+      await loadPreprocessedDatasetFromUrl(datasetFile,datasetLabel);
+    }
+  }catch(err){
+    console.error(`Failed to load dataset ${datasetFile}:`, err);
+    alert(`Unable to load dataset "${datasetLabel}": ${err?.message||err}`);
+    if(!state.hasData) setHasData(false);
+  }finally{
+    showLoading(false);
+  }
+}
+
+function promptInitialDatasetSelection(){
+  if(datasetPromptShown || state.hasData) return;
+  const menu=el.datasetMenu;
+  if(!menu?.list || !menu?.popup) return;
+  const firstOption=menu.list.querySelector('[data-dataset-id]');
+  if(!firstOption) return;
+  const opened=openDatasetMenu();
+  datasetPromptShown=true;
+  if(opened){
+    try{ firstOption.focus({preventScroll:true}); }catch(_){ }
+  }
+}
+
+function initDatasetMenu(){
+  const menu=el.datasetMenu;
+  if(!menu?.list) return;
+  const options=getBuiltinDatasetOptions();
+  menu.list.innerHTML='';
+  if(options.length){
+    options.forEach(opt=>{
+      const button=document.createElement('button');
+      button.type='button';
+      button.className='dataset-menu-item';
+      button.dataset.datasetId=opt.id;
+      button.dataset.datasetType=opt.type;
+      button.dataset.datasetFile=opt.file;
+      button.dataset.datasetLabel=opt.label;
+      button.setAttribute('role','menuitemradio');
+      button.setAttribute('aria-checked','false');
+      const metaText=opt.meta?`<span class="dataset-menu-meta">${escapeHtml(opt.meta)}</span>`:'';
+      button.innerHTML=`<span class="dataset-menu-name">${escapeHtml(opt.label)}</span>${metaText}<span class="dataset-menu-check" aria-hidden="true">✔</span>`;
+      menu.list.appendChild(button);
+    });
+    if(menu.empty) menu.empty.hidden=true;
+  }else if(menu.empty){
+    menu.empty.hidden=false;
+  }
+  if(menu.list) menu.list.hidden = !options.length;
+  if(menu.list && !menu.list.__datasetMenuBound){
+    menu.list.addEventListener('click', onDatasetMenuClick);
+    menu.list.__datasetMenuBound=true;
+  }
+  if(menu.btn && !menu.btn.__datasetMenuBound){
+    menu.btn.addEventListener('click', ev=>{
+      ev.preventDefault();
+      toggleDatasetMenu();
+    });
+    menu.btn.__datasetMenuBound=true;
+  }
+  renderEmptyStateDatasetOptions();
+  updateDatasetMenuActive();
+}
+
+
+async function onDatasetMenuClick(event){
+  const button=event.target.closest?.('[data-dataset-id]');
+  if(!button) return;
+  event.preventDefault();
+  const type=button.dataset.datasetType||'';
+  const file=button.dataset.datasetFile||'';
+  const label=button.dataset.datasetLabel || formatDatasetLabelFromFile(file);
+  closeDatasetMenu(false);
+  await handleDatasetSelection(type,file,label);
+}
+const DEFAULT_TAB_ORDER=['overview','overall','campaignPortfolio','targeting'];
+let TAB_ORDER=DEFAULT_TAB_ORDER.slice();
+const PIVOT_SORT_KEYS=new Set(['label','sku','brand','spend','sales','acos']);
+
+const kpiSparkCache=new Map();
+const copyFeedbackTimers=new WeakMap();
+const filterHighlightTimers=new WeakMap();
+const PIVOT_LABEL_COLLATOR=new Intl.Collator(undefined,{sensitivity:'base'});
+let lastKpiSeries=null;
+let pivotLayoutFrame=null;
+let skuSyncing=false;
+if(el.tabs?.list){ el.tabs.buttons = Array.from(el.tabs.list.querySelectorAll('[data-tab]')); }
+function clonePivotConfig(source){
+  const copy={};
+  Object.entries(source||{}).forEach(([key,value])=>{
+    copy[key]=Array.isArray(value)?value.map(item=>({...item})):[];
+  });
+  return copy;
+}
+const DEFAULT_PIVOT_CONFIG={
+  overview:[
+    {slot:'store', column:'store', fallback:'Store'},
+    {slot:'portfolio', column:'portfolio', fallback:'Portfolio Name', options:{caseInsensitive:true}},
+    {slot:'lo', column:'lo', fallback:'LO'},
+    {slot:'cat', column:'category', fallback:'Category'}
+  ],
+  overall:[
+    {slot:'store', column:'ttype', fallback:'Targeting Type'},
+    {slot:'lo', column:'tsub', fallback:'Targeting Sub Type'},
+    {slot:'custType', column:'customerType', fallback:'Customer Search Term - TYPE'},
+    {slot:'cat', column:'tsub2', fallback:'Targeting Sub Type2'},
+    {slot:'placement', column:'placement', fallback:'Placement'}
+  ],
+  campaignPortfolio:[
+    {slot:'campaign', column:'campaign', fallback:'Campaign Name'},
+    {slot:'adGroup', column:'adgroup', fallback:'Ad Group Name'}
+  ],
+  targeting:[
+    {slot:'targetingAsin', column:'targetingAsin', fallback:'Targeting ASIN'},
+    {slot:'targetingKeyword', column:'targeting', fallback:'Keyword', options:{displayName:'Keyword', baseFilters:[{stateKey:'tsub', values:['Keyword']}]}},
+    {slot:'targetingCat', column:'targetingCat', fallback:'Targeting CAT'}
+  ]
+};
+let PIVOT_CONFIG=clonePivotConfig(DEFAULT_PIVOT_CONFIG);
+const INITIAL_FILTER_KEYS=(()=>{
+  const keys=new Set(['term']);
+  (DEFAULT_PIVOT_CONFIG.overview||[]).forEach(cfg=>{
+    if(cfg?.column) keys.add(cfg.column);
+  });
+  return Array.from(keys);
+})();
+const FILTER_BACKFILL_CHUNK_SIZE=3;
+let filterBackfillToken=0;
+const pivotFilterPopupState={slot:'', options:[], filtered:[], dimension:null, button:null, displayName:'', search:'', mode:'dimension', dateTab:'months'};
+const DEFAULT_PREPROCESSED_DATA=[];
+const DEFAULT_WORKBOOKS=[
+  'Brands Campaign.xlsx'
+];
+const PREPROCESSED_WORKBOOK_MAP={
+  'brands campaign.xlsx':'preprocessed/Brands Campaign.json'
+};
+const API_BASE_URL=(typeof window!=='undefined' && window.PRODUCTS_SEARCH_TERM_API_BASE)
+  ? String(window.PRODUCTS_SEARCH_TERM_API_BASE).replace(/\/+$/,'')
+  : 'http://localhost:8000';
+const HAS_EXPLICIT_API_BASE=typeof window!=='undefined' && !!window.PRODUCTS_SEARCH_TERM_API_BASE;
+const WORKBOOK_API_ENDPOINT=`${API_BASE_URL}/api/workbook`;
+const LARGE_SHEET_ROW_THRESHOLD=100000;
+const LARGE_SHEET_CHUNK_SIZE=100000;
+const ASIN_SKU_WORKBOOK='ASINwise SKU.xlsx';
+const ADVERTISED_PRODUCTS_WORKBOOK=ASIN_SKU_WORKBOOK;
+let asinSkuPromise=null;
+let advertisedProductsPromise=null;
+let loadingDepth=0;
+let datasetPromptShown=false;
+
+function formatDatasetLabelFromFile(file){
+  if(!file) return '';
+  const parts=String(file).split(/[\\/]/);
+  const name=parts[parts.length-1]||String(file);
+  const withoutExt=name.replace(/\.[^.]+$/,'');
+  const prettified=withoutExt.replace(/[_-]+/g,' ').replace(/\s+/g,' ').trim();
+  return prettified||withoutExt||name;
+}
+
+function createDatasetId(type,file){
+  return `${type||''}:${(file||'').toLowerCase()}`;
+}
+
+function getBuiltinDatasetOptions(){
+  const options=[];
+  if(Array.isArray(DEFAULT_WORKBOOKS)){
+    DEFAULT_WORKBOOKS.forEach(file=>{
+      const trimmed=typeof file==='string'?file.trim():'';
+      if(!trimmed) return;
+      options.push({
+        id:createDatasetId('workbook', trimmed),
+        type:'workbook',
+        file:trimmed,
+        label:formatDatasetLabelFromFile(trimmed),
+        meta:'Workbook'
+      });
+    });
+  }
+  if(Array.isArray(DEFAULT_PREPROCESSED_DATA)){
+    DEFAULT_PREPROCESSED_DATA.forEach(file=>{
+      const trimmed=typeof file==='string'?file.trim():'';
+      if(!trimmed) return;
+      options.push({
+        id:createDatasetId('preprocessed', trimmed),
+        type:'preprocessed',
+        file:trimmed,
+        label:formatDatasetLabelFromFile(trimmed),
+        meta:'Preprocessed'
+      });
+    });
+  }
+  return options;
+}
+
+function renderEmptyStateDatasetOptions(){
+  const container=el.emptyDatasetOptions;
+  if(!container) return;
+  const options=getBuiltinDatasetOptions();
+  container.innerHTML='';
+  if(!options.length){
+    container.hidden=true;
+    container.setAttribute('hidden','');
+    container.setAttribute('aria-hidden','true');
+    return;
+  }
+  container.hidden=false;
+  container.removeAttribute('hidden');
+  container.removeAttribute('aria-hidden');
+  const frag=document.createDocumentFragment();
+  options.forEach(opt=>{
+    const button=document.createElement('button');
+    button.type='button';
+    button.className='empty-dataset-btn';
+    button.dataset.datasetId=opt.id;
+    button.dataset.datasetType=opt.type;
+    button.dataset.datasetFile=opt.file;
+    button.dataset.datasetLabel=opt.label;
+    button.textContent=opt.label;
+    button.setAttribute('aria-pressed','false');
+    frag.appendChild(button);
+  });
+  container.appendChild(frag);
+  if(!container.__datasetOptionsBound){
+    container.addEventListener('click', onEmptyDatasetOptionClick);
+    container.__datasetOptionsBound=true;
+  }
+}
+
+async function onEmptyDatasetOptionClick(event){
+  const button=event.target.closest?.('.empty-dataset-btn');
+  if(!button) return;
+  event.preventDefault();
+  const type=button.dataset.datasetType||'';
+  const file=button.dataset.datasetFile||'';
+  const label=button.dataset.datasetLabel || formatDatasetLabelFromFile(file);
+  if(isDatasetMenuOpen()) closeDatasetMenu(false);
+  await handleDatasetSelection(type,file,label);
+}
+
+function ensureAsinSkuMap(){
+  if(state.asinSkuLoaded){
+    if(!(state.asinBrandMap instanceof Map)) state.asinBrandMap=new Map();
+    return Promise.resolve(state.asinSkuMap instanceof Map ? state.asinSkuMap : new Map());
+  }
+  if(asinSkuPromise){
+    return asinSkuPromise;
+  }
+  asinSkuPromise=loadAsinSkuWorkbook().then(meta=>{
+    const skuMap = meta && meta.skuMap instanceof Map ? meta.skuMap : new Map();
+    const brandMap = meta && meta.brandMap instanceof Map ? meta.brandMap : new Map();
+    state.asinSkuMap = skuMap;
+    state.asinBrandMap = brandMap;
+    state.asinSkuLoaded=true;
+    if(state.hasData){
+      renderAll();
+      updateAllFilterOptions(null);
+    }
+    return state.asinSkuMap;
+  }).catch(()=>{
+    state.asinSkuMap=new Map();
+    state.asinBrandMap=new Map();
+    state.asinSkuLoaded=true;
+    return state.asinSkuMap;
+  });
+  return asinSkuPromise;
+}
+
+async function loadAsinSkuWorkbook(){
+  const file=ASIN_SKU_WORKBOOK && ASIN_SKU_WORKBOOK.trim();
+  if(!file) return {skuMap:new Map(), brandMap:new Map()};
+  try{
+    let targetUrl;
+    try{
+      targetUrl=new URL(file, document.baseURI).href;
+    }catch(_){
+      targetUrl=encodeURI(file);
+    }
+    const response=await fetch(targetUrl,{cache:'no-store'});
+    if(!response.ok && response.status!==0) throw new Error('ASIN SKU workbook not found');
+    const buf=await response.arrayBuffer();
+    const wb=XLSX.read(buf,{type:'array',cellDates:false,cellNF:false,cellText:false});
+    if(!wb.SheetNames || !wb.SheetNames.length) return {skuMap:new Map(), brandMap:new Map()};
+    let skuMap=null;
+    let brandMap=null;
+    for(const sheetName of wb.SheetNames){
+      const ws=wb.Sheets[sheetName];
+      if(!ws) continue;
+      const rows=XLSX.utils.sheet_to_json(ws,{header:1,raw:false,defval:''});
+      if(!rows || rows.length<2) continue;
+      if(!skuMap){
+        const candidate=buildAsinSkuMapFromRows(rows);
+        if(candidate) skuMap=candidate;
+      }
+      if(!brandMap){
+        const brandCandidate=buildAsinBrandMapFromRows(rows);
+        if(brandCandidate) brandMap=brandCandidate;
+      }
+      if(skuMap && brandMap) break;
+    }
+    return {
+      skuMap:skuMap||new Map(),
+      brandMap:brandMap||new Map()
+    };
+  }catch(err){
+    console.warn('ASIN SKU mapping load failed:', err);
+    return {skuMap:new Map(), brandMap:new Map()};
+  }
+}
+
+function normalizeAsinKey(value){
+  return value==null ? '' : String(value).trim().toUpperCase();
+}
+
+function normalizeSkuKey(value){
+  return value==null ? '' : String(value).trim().toLowerCase();
+}
+
+function lookupAsinSkus(value){
+  const key=normalizeAsinKey(value);
+  if(!key) return null;
+  const map=state.asinSkuMap;
+  if(!(map instanceof Map)) return null;
+  const list=map.get(key);
+  return Array.isArray(list) && list.length ? list : null;
+}
+
+function lookupAsinBrand(value){
+  const key=normalizeAsinKey(value);
+  if(!key) return '';
+  const map=state.asinBrandMap;
+  if(!(map instanceof Map)) return '';
+  const brand=map.get(key);
+  return brand==null?'':String(brand).trim();
+}
+
+function formatSkuEntries(entries){
+  if(!Array.isArray(entries) || !entries.length) return '';
+  const seen=new Set();
+  const parts=[];
+  for(const entry of entries){
+    const sellerRaw=entry?.sellerSku==null?'':String(entry.sellerSku).trim();
+    const plainRaw=entry?.plainSku==null?'':String(entry.plainSku).trim();
+    const value=sellerRaw||plainRaw;
+    if(!value) continue;
+    const key=value.toLowerCase();
+    if(seen.has(key)) continue;
+    seen.add(key);
+    parts.push(value);
+  }
+  return parts.join(', ');
+}
+
+function ensureAdvertisedProductsData(){
+  const entry=state.advertisedProducts;
+  if(entry?.loaded){
+    return Promise.resolve(Array.isArray(entry.rows)?entry.rows:[]);
+  }
+  if(advertisedProductsPromise){
+    return advertisedProductsPromise;
+  }
+  advertisedProductsPromise=loadAdvertisedProductsWorkbook().then(rows=>{
+    if(entry){
+      entry.rows=Array.isArray(rows)?rows:[];
+      entry.loaded=true;
+    }
+    return entry?.rows||[];
+  }).catch(err=>{
+    console.warn('Advertised products workbook load failed:', err);
+    if(entry){
+      entry.rows=[];
+      entry.loaded=false;
+    }
+    throw err;
+  }).finally(()=>{
+    advertisedProductsPromise=null;
+  });
+  return advertisedProductsPromise;
+}
+
+async function loadAdvertisedProductsWorkbook(){
+  const file=ADVERTISED_PRODUCTS_WORKBOOK && ADVERTISED_PRODUCTS_WORKBOOK.trim();
+  if(!file) return [];
+  let targetUrl;
+  try{
+    targetUrl=new URL(file, document.baseURI).href;
+  }catch(_){
+    targetUrl=encodeURI(file);
+  }
+  const response=await fetch(targetUrl,{cache:'no-store'});
+  if(!response.ok && response.status!==0) throw new Error('Advertised product workbook not found');
+  const buf=await response.arrayBuffer();
+  const wb=XLSX.read(buf,{type:'array',cellDates:false,cellNF:false,cellText:false});
+  if(!wb.SheetNames || !wb.SheetNames.length) return [];
+  for(const sheetName of wb.SheetNames){
+    const ws=wb.Sheets[sheetName];
+    if(!ws) continue;
+    const rows=XLSX.utils.sheet_to_json(ws,{header:1,raw:false,defval:''});
+    if(!rows || rows.length<2) continue;
+    const data=buildAdvertisedProductsFromRows(rows);
+    if(data && data.length) return data;
+  }
+  return [];
+}
+
+function sanitizeRow(row){
+  return (row||[]).map(v=>String(v??'').trim());
+}
+
+function buildAsinSkuMapFromRows(rows){
+  if(!Array.isArray(rows) || !rows.length) return null;
+  const preferredHeaderIndex=rows.length>1?1:0;
+  let headerIndex=preferredHeaderIndex;
+  let headers=sanitizeRow(rows[headerIndex]||[]);
+  let asinIdx=findIndexByTokens(headers,['advertisedasin','asin']);
+  let sellerIdx=findIndexByTokens(headers,['sellersku','seller sku','seller-sku']);
+  let plainIdx=findIndexByTokens(headers,['plainsku','plain sku','plain-sku']);
+  let skuIdx=findIndexByTokens(headers,['advertisedsku','sku']);
+  if(
+    asinIdx<0 ||
+    (sellerIdx<0 && plainIdx<0 && skuIdx<0)
+  ){
+    for(let i=0;i<Math.min(rows.length,6);i++){
+      const candidate=sanitizeRow(rows[i]);
+      const aIdx=findIndexByTokens(candidate,['advertisedasin','asin']);
+      const sellerCandidate=findIndexByTokens(candidate,['sellersku','seller sku','seller-sku']);
+      const plainCandidate=findIndexByTokens(candidate,['plainsku','plain sku','plain-sku']);
+      const skuCandidate=findIndexByTokens(candidate,['advertisedsku','sku']);
+      if(aIdx>-1 && (sellerCandidate>-1 || plainCandidate>-1 || skuCandidate>-1)){
+        headerIndex=i;
+        headers=candidate;
+        asinIdx=aIdx;
+        sellerIdx=sellerCandidate;
+        plainIdx=plainCandidate;
+        skuIdx=skuCandidate;
+        break;
+      }
+    }
+  }
+  if(asinIdx<0 || (sellerIdx<0 && plainIdx<0 && skuIdx<0)) return null;
+  const map=new Map();
+  for(let i=headerIndex+1;i<rows.length;i++){
+    const row=Array.isArray(rows[i])?rows[i]:[];
+    const asin=String(row[asinIdx]??'').trim();
+    if(!asin) continue;
+    const sellerSkuRaw=sellerIdx>-1?String(row[sellerIdx]??'').trim():'';
+    const plainSkuRaw=plainIdx>-1?String(row[plainIdx]??'').trim():'';
+    const fallbackSku=skuIdx>-1?String(row[skuIdx]??'').trim():'';
+    const sellerSku=sellerSkuRaw || fallbackSku;
+    const plainSku=plainSkuRaw || fallbackSku;
+    if(!sellerSku && !plainSku) continue;
+    const asinKey=normalizeAsinKey(asin);
+    if(!asinKey) continue;
+    let list=map.get(asinKey);
+    if(!list){
+      list=[];
+      map.set(asinKey,list);
+    }
+    const entry={
+      sellerSku:sellerSku,
+      plainSku:plainSku
+    };
+    if(!list.some(item=>item && item.sellerSku===entry.sellerSku && item.plainSku===entry.plainSku)){
+      list.push(entry);
+    }
+  }
+  if(!map.size) return null;
+  const collator=new Intl.Collator(undefined,{sensitivity:'base',numeric:true});
+  map.forEach(list=>list.sort((a,b)=>{
+    const aSeller=String(a?.sellerSku||a?.plainSku||'');
+    const bSeller=String(b?.sellerSku||b?.plainSku||'');
+    const sellerDiff=collator.compare(aSeller,bSeller);
+    if(sellerDiff!==0) return sellerDiff;
+    const aPlain=String(a?.plainSku||'');
+    const bPlain=String(b?.plainSku||'');
+    return collator.compare(aPlain,bPlain);
+  }));
+  return map;
+}
+
+function buildAsinBrandMapFromRows(rows){
+  if(!Array.isArray(rows) || !rows.length) return null;
+  const preferredHeaderIndex=rows.length>1?1:0;
+  let headerIndex=preferredHeaderIndex;
+  let headers=sanitizeRow(rows[headerIndex]||[]);
+  let asinIdx=findIndexByTokens(headers,['advertisedasin','asin']);
+  let brandIdx=findIndexByTokens(headers,['brand','brandname','brand name','store','seller']);
+  if(asinIdx<0 || brandIdx<0){
+    for(let i=0;i<Math.min(rows.length,6);i++){
+      const candidate=sanitizeRow(rows[i]);
+      const aIdx=findIndexByTokens(candidate,['advertisedasin','asin']);
+      const bIdx=findIndexByTokens(candidate,['brand','brandname','brand name','store','seller']);
+      if(aIdx>-1 && bIdx>-1){
+        headerIndex=i;
+        headers=candidate;
+        asinIdx=aIdx;
+        brandIdx=bIdx;
+        break;
+      }
+    }
+  }
+  if(asinIdx<0 || brandIdx<0) return null;
+  const map=new Map();
+  for(let i=headerIndex+1;i<rows.length;i++){
+    const row=Array.isArray(rows[i])?rows[i]:[];
+    const asin=String(row[asinIdx]??'').trim();
+    const brand=String(row[brandIdx]??'').trim();
+    if(!asin || !brand) continue;
+    const asinKey=normalizeAsinKey(asin);
+    if(!asinKey) continue;
+    const existing=map.get(asinKey);
+    if(!existing || String(existing).trim().length < brand.length){
+      map.set(asinKey, brand);
+    }
+  }
+  return map.size?map:null;
+}
+
+function buildAdvertisedProductsFromRows(rows){
+  if(!Array.isArray(rows) || !rows.length) return null;
+  const preferredHeaderIndex=rows.length>1?1:0;
+  let headerIndex=preferredHeaderIndex;
+  let headers=sanitizeRow(rows[headerIndex]||[]);
+  let idxCampaign=findIndexByTokens(headers,['campaignname','campaign']);
+  let idxAdGroup=findIndexByTokens(headers,['adgroupname','ad group name','adgroup']);
+  let idxSku=findIndexByTokens(headers,['advertisedsku','sku']);
+  let idxAsin=findIndexByTokens(headers,['advertisedasin','asin']);
+  if((idxCampaign<0 && idxAdGroup<0) || (idxSku<0 && idxAsin<0)){
+    for(let i=0;i<Math.min(rows.length,6);i++){
+      const candidate=sanitizeRow(rows[i]);
+      const campaignCandidate=findIndexByTokens(candidate,['campaignname','campaign']);
+      const adGroupCandidate=findIndexByTokens(candidate,['adgroupname','ad group name','adgroup']);
+      const skuCandidate=findIndexByTokens(candidate,['advertisedsku','sku']);
+      const asinCandidate=findIndexByTokens(candidate,['advertisedasin','asin']);
+      const hasNames=(campaignCandidate>-1 || adGroupCandidate>-1);
+      const hasProducts=(skuCandidate>-1 || asinCandidate>-1);
+      if(hasNames && hasProducts){
+        headerIndex=i;
+        headers=candidate;
+        idxCampaign=campaignCandidate;
+        idxAdGroup=adGroupCandidate;
+        idxSku=skuCandidate;
+        idxAsin=asinCandidate;
+        break;
+      }
+    }
+    if((idxCampaign<0 && idxAdGroup<0) || (idxSku<0 && idxAsin<0)){
+      headerIndex=preferredHeaderIndex;
+      headers=sanitizeRow(rows[headerIndex]||[]);
+      idxCampaign=findIndexByTokens(headers,['campaignname','campaign']);
+      idxAdGroup=findIndexByTokens(headers,['adgroupname','ad group name','adgroup']);
+      idxSku=findIndexByTokens(headers,['advertisedsku','sku']);
+      idxAsin=findIndexByTokens(headers,['advertisedasin','asin']);
+    }
+  }
+  if(idxCampaign<0 && idxAdGroup<0) return null;
+  if(idxSku<0 && idxAsin<0) return null;
+  const data=[];
+  for(let i=headerIndex+1;i<rows.length;i++){
+    const row=Array.isArray(rows[i])?rows[i]:[];
+    const campaign=idxCampaign>-1?String(row[idxCampaign]??'').trim():'';
+    const adGroup=idxAdGroup>-1?String(row[idxAdGroup]??'').trim():'';
+    const sku=idxSku>-1?String(row[idxSku]??'').trim():'';
+    const asin=idxAsin>-1?String(row[idxAsin]??'').trim():'';
+    if(!campaign && !adGroup) continue;
+    if(!sku && !asin) continue;
+    data.push({
+      campaign,
+      adGroup,
+      sku,
+      asin,
+      campaignKey:normalizeAdvertisedKey(campaign),
+      adGroupKey:normalizeAdvertisedKey(adGroup)
+    });
+  }
+  return data.length?data:null;
+}
+
+function skuEntriesToValues(entries){
+  if(!Array.isArray(entries) || !entries.length) return [];
+  const seen=new Set();
+  const values=[];
+  entries.forEach(entry=>{
+    if(!entry) return;
+    ['sellerSku','plainSku'].forEach(key=>{
+      const raw=entry?.[key];
+      if(raw==null) return;
+      const value=String(raw).trim();
+      if(!value) return;
+      const norm=normalizeSkuKey(value);
+      if(seen.has(norm)) return;
+      seen.add(norm);
+      values.push(value);
+    });
+  });
+  return values;
+}
+
+function resetConversionPaging(){
+  state.conversionPage={st:0,asin:0};
+}
+
+function initConversionNav(){
+  const attach=(target,slot)=>{
+    if(!target?.card) return;
+    if(!target.nav){
+      target.nav=target.card.querySelector('.pivot-pagination');
+    }
+    if(!target.nav) return;
+    if(!target.navLabel) target.navLabel=target.nav.querySelector('.pivot-nav-label');
+    if(!target.navPrev) target.navPrev=target.nav.querySelector('.pivot-nav-btn.prev');
+    if(!target.navNext) target.navNext=target.nav.querySelector('.pivot-nav-btn.next');
+    const key=slot==='conversionAsin'?'asin':'st';
+    if(target.navPrev && !target.navPrev.__bound){
+      target.navPrev.__bound=true;
+      target.navPrev.addEventListener('click',()=>goToConversionPage(key,-1));
+    }
+    if(target.navNext && !target.navNext.__bound){
+      target.navNext.__bound=true;
+      target.navNext.addEventListener('click',()=>goToConversionPage(key,1));
+    }
+  };
+  attach(el.pivot?.conversionSt,'conversionSt');
+  attach(el.pivot?.conversionAsin,'conversionAsin');
+}
+
+function goToConversionPage(which, delta){
+  if(!state.conversionPage) state.conversionPage={st:0,asin:0};
+  const key=which==='asin'?'asin':'st';
+  const current=state.conversionPage[key]||0;
+  const next=Math.max(0, current+delta);
+  if(next===current) return;
+  state.conversionPage[key]=next;
+  renderAll();
+}
+
+function updateConversionNav(target, agg){
+  if(!target) return;
+  if(!target.nav && target.card){
+    target.nav=target.card.querySelector('.pivot-pagination');
+    if(target.nav){
+      target.navLabel=target.nav.querySelector('.pivot-nav-label');
+      target.navPrev=target.nav.querySelector('.pivot-nav-btn.prev');
+      target.navNext=target.nav.querySelector('.pivot-nav-btn.next');
+    }
+  }
+  if(!target.nav) return;
+  const page=agg?.page;
+  const total=Number.isFinite(agg?.total)?agg.total:0;
+  const count=Array.isArray(agg?.labels)?agg.labels.length:0;
+  if(target.navLabel){
+    if(total && count){
+      const start=Number.isFinite(page?.start)?page.start:0;
+      const from=Math.min(total,start+1);
+      const to=Math.min(total,start+count);
+      target.navLabel.textContent=`${from.toLocaleString()}–${to.toLocaleString()} of ${total.toLocaleString()}`;
+    }else if(total){
+      target.navLabel.textContent=`0 of ${total.toLocaleString()}`;
+    }else{
+      target.navLabel.textContent='No rows';
+    }
+  }
+  if(target.navPrev) target.navPrev.disabled=!(page && page.hasPrev);
+  if(target.navNext) target.navNext.disabled=!(page && page.hasNext);
+  target.nav.hidden = total<=0;
+  const idle=!(page && (page.hasPrev || page.hasNext));
+  target.nav.classList.toggle('is-idle', idle);
+}
+
+
+/* ===== theme + boot ===== */
+document.addEventListener('DOMContentLoaded', () => {
+  const saved=localStorage.getItem('theme')||'dark';
+  if(saved==='light') document.body.classList.add('light');
+  updateThemeBtn();
+  el.themeBtn.addEventListener('click',()=>{
+    document.body.classList.toggle('light');
+    localStorage.setItem('theme', document.body.classList.contains('light')?'light':'dark');
+    updateThemeBtn(); renderAll();
+  });
+  function updateThemeBtn(){
+    const light=document.body.classList.contains('light');
+    el.themeBtn.querySelector('.icon').textContent= light?'🌙':'☀️';
+  }
+  boot();
+  window.addEventListener('resize', debounce(()=>{
+    schedulePivotLayout();
+    if(lastKpiSeries) updateKpiSparks(lastKpiSeries);
+  },180));
+});
+
+function setupTabs(){
+  if(!el.tabs?.buttons?.length) return;
+  state.lastTabIndex = TAB_ORDER.indexOf(state.activeTab);
+  el.tabs.buttons.forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const tab=btn.dataset.tab;
+      if(!tab || state.activeTab===tab) return;
+      const prevIndex = TAB_ORDER.indexOf(state.activeTab);
+      const newIndex = TAB_ORDER.indexOf(tab);
+      state.activeTab=tab;
+      if(prevIndex>-1 && newIndex>-1 && prevIndex!==newIndex){
+        animatePivot(newIndex>prevIndex?'forward':'backward');
+      }
+      state.lastTabIndex=newIndex;
+      updateTabsUI();
+      renderAll();
+    });
+  });
+  updateTabsUI();
+}
+function updateTabsUI(){
+  const buttons=el.tabs?.buttons||[];
+  const active=state.activeTab||'overview';
+  buttons.forEach(btn=>{
+    const tab=btn.dataset.tab;
+    const on=tab===active;
+    btn.classList.toggle('is-active', on);
+    btn.setAttribute('aria-selected', on?'true':'false');
+    btn.setAttribute('tabindex', on?'0':'-1');
+  });
+}
+function animatePivot(direction){
+  const target=el.pivot?.section;
+  if(!target) return;
+  target.classList.remove('pivot-animate-forward','pivot-animate-backward');
+  void target.offsetWidth;
+  const cls = direction==='backward'?'pivot-animate-backward':'pivot-animate-forward';
+  target.classList.add(cls);
+  const handler=()=>{
+    target.classList.remove('pivot-animate-forward','pivot-animate-backward');
+    target.removeEventListener('animationend', handler);
+  };
+  target.addEventListener('animationend', handler);
+}
+
+function setupPivotInteractions(){
+  const root=el.pivot?.section;
+  if(!root) return;
+  root.addEventListener('click', handlePivotSectionClick);
+  root.addEventListener('keydown', handlePivotHeaderKeydown);
+}
+
+function handlePivotSectionClick(event){
+  const copyBtn=event.target.closest?.('.pivot-copy-btn');
+  if(copyBtn){
+    event.preventDefault();
+    handlePivotCopy(copyBtn);
+    return;
+  }
+  const clearBtn=event.target.closest?.('.pivot-clear-btn');
+  if(clearBtn){
+    event.preventDefault();
+    event.stopPropagation();
+    handlePivotClearButton(clearBtn);
+    return;
+  }
+  const filterBtn=event.target.closest?.('.pivot-filter-btn');
+  if(filterBtn){
+    event.preventDefault();
+    event.stopPropagation();
+    handlePivotFilterButton(filterBtn);
+    return;
+  }
+  const labelBtn=event.target.closest?.('.pivot-label-btn');
+  if(labelBtn){
+    event.preventDefault();
+    event.stopPropagation();
+    handlePivotLabelButton(labelBtn);
+    return;
+  }
+  const header=event.target.closest?.('th[data-sort-key]');
+  if(header){
+    event.preventDefault();
+    togglePivotSort(header);
+  }
+}
+
+function handlePivotHeaderKeydown(event){
+  const header=event.target.closest?.('th[data-sort-key]');
+  if(!header) return;
+  if(event.key==='Enter' || event.key===' ' || event.key==='Spacebar'){
+    event.preventDefault();
+    togglePivotSort(header);
+  }
+}
+
+function handlePivotLabelButton(button){
+  if(!button) return;
+  const table=button.closest('table.pivot-table');
+  if(!table) return;
+  const value=button.dataset.pivotValue;
+  const matchKey=button.dataset.pivotMatch;
+  applyPivotLabelFilter(table, value, matchKey);
+}
+
+function applyPivotLabelFilter(table, rawValue, matchKey){
+  if(!table) return;
+  const dimension=getPivotDimensionForTable(table);
+  if(!dimension) return;
+  const stateKey=dimension.stateKey;
+  if(!stateKey) return;
+  if(state.advertisedProducts && (stateKey==='campaign' || stateKey==='adgroup')){
+    state.advertisedProducts.lastSlot=stateKey;
+  }
+  const root=el.dd?.[stateKey];
+  if(!root) return;
+  const keys=pivotMakeValueKeys(rawValue, matchKey, dimension);
+  if(!keys.raw) return;
+  const normalizedTarget = dimension.caseInsensitive ? keys.normalized : keys.raw;
+  const checkboxes=Array.from(root.querySelectorAll('.dd-list input[type=checkbox]'));
+  if(!checkboxes.length) return;
+  const normalizeValue=value=> dimension.caseInsensitive ? String(value||'').toLocaleLowerCase() : String(value||'');
+  const currentSelection=ddGetSelected(root).map(normalizeValue);
+  const alreadyOnlySelected=currentSelection.length===1 && currentSelection[0]===normalizedTarget;
+  let matched=false;
+  checkboxes.forEach(cb=>{
+    const value=normalizeValue(cb.value);
+    if(alreadyOnlySelected){
+      cb.checked=false;
+      return;
+    }
+    const isMatch=value===normalizedTarget;
+    if(isMatch) matched=true;
+    cb.checked=isMatch;
+  });
+  if(alreadyOnlySelected){
+    matched=true;
+  }
+  if(!matched) return;
+  ddUpdateSummary(root);
+  ddSyncSelectAll(root);
+  ddRefreshSearchSelections(root);
+  if(root.classList.contains('dd-search-mode')){
+    ddApplyImmediateFilters(root);
+  }else if(state.hasData){
+    updateAllFilterOptions(null);
+    resetConversionPaging();
+    renderAll();
+    updateResetButtonVisibility();
+  }
+}
+
+function togglePivotSort(header){
+  if(!header) return;
+  const table=header.closest('table.pivot-table');
+  if(!table || !table._pivotData) return;
+  const key=header.dataset.sortKey;
+  if(!PIVOT_SORT_KEYS.has(key)) return;
+  const sort=table._pivotSort || (table._pivotSort={key:null,dir:'desc'});
+  if(sort.key===key){
+    sort.dir = sort.dir==='desc' ? 'asc' : 'desc';
+  }else{
+    sort.key = key;
+    sort.dir = key==='label' ? 'asc' : 'desc';
+  }
+  renderPivotTable(table);
+}
+
+async function handlePivotCopy(button){
+  if(!button) return;
+  const tableId=button.dataset.copyTarget;
+  let table=null;
+  if(tableId) table=document.getElementById(tableId);
+  if(!table){
+    table=button.closest('.pivot-card')?.querySelector('table');
+  }
+  if(!table){
+    console.warn('Pivot copy: target table not found');
+    return;
+  }
+  const text=pivotTableToClipboardText(table);
+  if(!text){
+    console.warn('Pivot copy: no content to copy');
+    return;
+  }
+  try{
+    await copyTextToClipboard(text);
+    showPivotCopySuccess(button);
+  }catch(err){
+    console.error('Failed to copy pivot table', err);
+    alert('Unable to copy table to clipboard. Please copy manually.');
+  }
+}
+
+function pivotTableToClipboardText(table){
+  if(!table) return '';
+  const rows=[];
+  ['thead','tbody','tfoot'].forEach(sectionName=>{
+    const section=table.querySelector(sectionName);
+    if(!section) return;
+    section.querySelectorAll('tr').forEach(tr=>{
+      const cells=Array.from(tr.children||[])
+        .filter(cell=>!cell.classList?.contains('pivot-acos-bar') && cell.getAttribute?.('aria-hidden')!=='true')
+        .map(cell=>String(cell.textContent||'').replace(/\s+/g,' ').trim());
+      if(cells.length) rows.push(cells.join('\t'));
+    });
+  });
+  return rows.join('\n').trim();
+}
+
+async function copyTextToClipboard(text){
+  if(!text) return;
+  if(navigator.clipboard?.writeText){
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea=document.createElement('textarea');
+  textarea.value=text;
+  textarea.setAttribute('readonly','');
+  textarea.style.position='fixed';
+  textarea.style.opacity='0';
+  textarea.style.pointerEvents='none';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try{
+    const ok=document.execCommand('copy');
+    if(!ok) throw new Error('Copy command was rejected');
+  }finally{
+    document.body.removeChild(textarea);
+  }
+}
+
+function showPivotCopySuccess(button){
+  if(!button) return;
+  button.classList.add('is-copied');
+  const timer=copyFeedbackTimers.get(button);
+  if(timer) clearTimeout(timer);
+  const timeout=setTimeout(()=>{
+    button.classList.remove('is-copied');
+    copyFeedbackTimers.delete(button);
+  },1600);
+  copyFeedbackTimers.set(button, timeout);
+}
+function getPivotConfig(){ return PIVOT_CONFIG[state.activeTab] || PIVOT_CONFIG.overview; }
+
+function boot(){
+  setHasData(false);
+  initDatasetMenu();
+  setupTabs();
+  assignPivotSlots();
+  updatePivotFilterButtons();
+  initConversionNav();
+  sqlReadyPromise = loadSqlLibrary();
+  const triggerPicker=()=>{ if(el.fileInput) el.fileInput.click(); };
+  if(el.pickLocalBtn) el.pickLocalBtn.addEventListener('click', triggerPicker);
+  if(el.emptyOpen){
+    el.emptyOpen.addEventListener('click', triggerPicker);
+  }
+  if(el.fileInput) el.fileInput.addEventListener('change', handleLocalFile);
+  if(el.dlCsv) el.dlCsv.addEventListener('click', onDownloadCsv);
+  el.openFiltersBtn.addEventListener('click', ()=>{
+    state.filtersReturn=el.openFiltersBtn;
+    openFiltersModal();
+  });
+  el.closeFiltersBtn.addEventListener('click', closeFiltersCancel);
+  el.cancelFiltersBtn.addEventListener('click', closeFiltersCancel);
+  el.applyFiltersBtn.addEventListener('click', closeFiltersApply);
+  el.clearAllBtn.addEventListener('click', clearAllFilters);
+  if(el.resetFiltersBtn) el.resetFiltersBtn.addEventListener('click', resetFiltersAndApply);
+  const monthControl=el.monthDD.querySelector('.dd-control');
+  monthControl.addEventListener('click', ()=>{
+    const wasOpen=el.monthDD.classList.contains('open');
+    el.monthDD.classList.toggle('open');
+    if(!wasOpen){
+      clampPanelRight(el.monthDD.querySelector('.dd-panel'));
+      state.monthTab = state.customRange.active ? 'custom' : 'months';
+      updateMonthTabs();
+    }else{
+      applyMonthFilters();
+    }
+  });
+  if(el.monthTabList) el.monthTabList.addEventListener('click', handleMonthTabClick);
+  if(el.monthCustomPanel){
+    el.monthCustomPanel.addEventListener('click', ev=>ev.stopPropagation());
+    el.monthCustomPanel.addEventListener('mousedown', ev=>ev.stopPropagation());
+  }
+  if(el.monthCustomApply) el.monthCustomApply.addEventListener('click', applyCustomRangeFromInputs);
+  if(el.monthCustomCancel) el.monthCustomCancel.addEventListener('click', handleCustomRangeCancel);
+
+  document.addEventListener('click', (e)=>{
+    if(isDatasetMenuOpen()){
+      const menuRoot=el.datasetMenu?.container;
+      if(menuRoot && !menuRoot.contains(e.target)){
+        closeDatasetMenu(false);
+      }
+    }
+    const monthRoot=el.monthDD;
+    const clickedInsideMonth=monthRoot?.contains?.(e.target);
+    if(monthRoot && !clickedInsideMonth && monthRoot.classList.contains('open')){
+      monthRoot.classList.remove('open');
+      state.monthTab=state.customRange.active?'custom':'months';
+      updateMonthTabs();
+      applyMonthFilters();
+    }
+    const clickedDd=e.target.closest('.dd');
+    document.querySelectorAll('.dd.open').forEach(d=>{
+      if(d!==clickedDd){
+        d.classList.remove('open');
+        const panel=d.querySelector('.dd-panel');
+        if(panel){
+          panel.hidden=true;
+          panel.setAttribute('hidden','');
+        }
+      }
+    });
+    const popupRoot=el.pivotPopup?.root;
+    if(popupRoot && !popupRoot.hasAttribute('hidden')){
+      const clickedPopup=e.target.closest?.('#pivotFilterPopup');
+      const clickedButton=e.target.closest?.('.pivot-filter-btn');
+      if(!clickedPopup && !clickedButton){
+        closePivotFilterPopup(false);
+      }
+    }
+  });
+
+  setupPivotInteractions();
+  ensureAdvertisedProductsData().catch(()=>{});
+
+  if(el.pivotPopup?.close) el.pivotPopup.close.addEventListener('click', ()=>closePivotFilterPopup());
+  if(el.pivotPopup?.clear) el.pivotPopup.clear.addEventListener('click', ()=>{
+    const slot=pivotFilterPopupState.slot;
+    const changed=slot?clearPivotFilterState(slot):false;
+    closePivotFilterPopup();
+    if(changed) renderAll();
+    else updatePivotFilterButtons();
+  });
+  if(el.pivotPopup?.search) el.pivotPopup.search.addEventListener('input', handlePivotPopupSearchInput);
+  if(el.pivotPopup?.selectAll) el.pivotPopup.selectAll.addEventListener('change', handlePivotPopupSelectAll);
+  if(el.pivotPopup?.list) el.pivotPopup.list.addEventListener('change', handlePivotPopupListChange);
+
+  document.addEventListener('keydown', (ev)=>{
+    if(ev.key==='Escape' || ev.key==='Esc'){
+      if(isDatasetMenuOpen()){
+        if(closeDatasetMenu()){
+          ev.stopPropagation();
+          ev.preventDefault();
+          return;
+        }
+      }
+      if(closePivotFilterPopup(false)){
+        ev.stopPropagation();
+        ev.preventDefault();
+      }
+    }
+  });
+
+  showLoading(false,{force:true});
+  el.tipPill.hidden=true;
+  el.monthsWrap.hidden=true;
+  const scheduleDatasetPrompt=()=>promptInitialDatasetSelection();
+  if(typeof requestAnimationFrame==='function') requestAnimationFrame(scheduleDatasetPrompt);
+  else setTimeout(scheduleDatasetPrompt,0);
+}
+function showLoading(on, options={}){
+  const force=!!options.force;
+  if(on){
+    loadingDepth=Math.max(loadingDepth+1,1);
+  }else if(force){
+    loadingDepth=0;
+  }else if(loadingDepth>0){
+    loadingDepth-=1;
+  }
+  const active=loadingDepth>0;
+  if(el.status){
+    el.status.classList.toggle('show', active);
+    el.status.style.display=active?'':'none';
+  }
+  if(!active) updateLoadingProgress();
+}
+
+function resetKpis(){ Object.values(el.kpi||{}).forEach(node=>{ if(node) node.textContent='—'; }); lastKpiSeries=null; updateKpiSparks(null); }
+
+function setHasData(has){
+  state.hasData=!!has;
+  if(has){
+    showLoading(false,{force:true});
+  }
+  document.body.classList.toggle('has-data', !!has);
+  if(has){
+    if(el.topLine) el.topLine.style.display='flex';
+    if(el.kpis) el.kpis.hidden=false;
+    if(el.pivot?.section) el.pivot.section.hidden=false;
+    if(el.openFiltersBtn) el.openFiltersBtn.style.display='inline-flex';
+    if(el.dlCsv) el.dlCsv.disabled=false;
+    if(el.monthsWrap) el.monthsWrap.hidden = state.monthOptions.length===0;
+    if(el.tabs?.bar) el.tabs.bar.hidden=false;
+    if(el.tipPill) el.tipPill.hidden=true;
+    if(lastKpiSeries){
+      const redraw=()=>updateKpiSparks(lastKpiSeries);
+      if(typeof requestAnimationFrame==='function'){ requestAnimationFrame(redraw); }
+      else redraw();
+    }
+  }else{
+    datasetPromptShown=false;
+    filterBackfillToken+=1;
+    if(el.topLine) el.topLine.style.display='none';
+    if(el.kpis) el.kpis.hidden=true;
+    if(el.pivot?.section) el.pivot.section.hidden=true;
+    if(el.openFiltersBtn) el.openFiltersBtn.style.display='none';
+    if(el.dlCsv) el.dlCsv.disabled=true;
+    if(el.monthsWrap) el.monthsWrap.hidden=true;
+    if(el.tabs?.bar) el.tabs.bar.hidden=true;
+    if(el.tipPill) el.tipPill.hidden=false;
+    if(el.advertisedProducts?.card) el.advertisedProducts.card.hidden=true;
+    if(state.advertisedProducts){
+      state.advertisedProducts.renderToken=0;
+      state.advertisedProducts.lastSlot=null;
+    }
+    closePivotFilterPopup(false);
+    state.columns={};
+    state.rows=[];
+    state.asinValueMap=new Map();
+    state.monthSel.clear();
+    state.monthOptions=[];
+    state.monthDirty=false;
+    state.customRange={start:null,end:null,active:false};
+    state.dateBounds={min:null,max:null};
+    state.monthTab='months';
+    updateMonthTabs();
+    syncCustomRangeInputs();
+    state.pivotFilters={};
+    state.activePivotPopup=null;
+    state.activePivotModal=null;
+    resetConversionPaging();
+    if(el.monthList) el.monthList.innerHTML='';
+    syncFilterLabels();
+    state.activeTab='overview';
+    if(state.sql?.db){
+      try{ state.sql.db.close(); }catch(_){ }
+    }
+    state.sql={db:null, table:'', columns:[], columnMap:new Map(), rowCount:0};
+    state.lastTabIndex=TAB_ORDER.indexOf('overview');
+    resetKpis();
+    hideCustomRangePanel();
+    syncCustomRangeInputs();
+    setActiveDataset(null);
+    closeDatasetMenu(false);
+    promptInitialDatasetSelection();
+  }
+  updateTabButtonsForOrder(TAB_ORDER);
+  updateMonthSummary();
+  updateTabsUI();
+  updateResetButtonVisibility();
+  updateDatasetMeta();
+}
+
+/* ===== Excel parsing (headers row auto-detected) ===== */
+function findIndexByTokens(headers, tokens){
+  const HX=headers.map(h=>String(h||'').toLowerCase().replace(/[^a-z0-9]+/g,''));
+  const searchTokens=(Array.isArray(tokens)?tokens:[])
+    .map(t=>String(t||'').toLowerCase().replace(/[^a-z0-9]+/g,''))
+    .filter(Boolean);
+  if(!searchTokens.length) return -1;
+  for(const token of searchTokens){
+    const idx=HX.indexOf(token);
+    if(idx>-1) return idx;
+  }
+  let bestIndex=-1;
+  let bestScore=0;
+  for(let i=0;i<HX.length;i++){
+    const header=HX[i];
+    if(!header) continue;
+    for(const token of searchTokens){
+      const pos=header.indexOf(token);
+      if(pos===-1) continue;
+      let score=token.length/Math.max(header.length,1);
+      if(pos===0) score+=0.15;
+      if(pos+token.length===header.length) score+=0.35;
+      if(score>bestScore){
+        bestScore=score;
+        bestIndex=i;
+      }
+    }
+  }
+  return bestScore>0?bestIndex:-1;
+}
+const HEADER_ROW_SCORE_GROUPS=(
+  [
+    ['store','lo','market','site','locale','country','account'],
+    ['sales','revenue','totalsales','orderedrevenue','attributedsales'],
+    ['spend','adspend','cost','advertisingcost'],
+    ['clicks'],
+    ['impressions','impr'],
+    ['customersearchterm','searchterm','term'],
+    ['campaignname','campaign'],
+    ['adgroupname','adgroup'],
+    ['portfolioname','portfolio'],
+    ['placement'],
+    ['targetingtype','adtype','type'],
+    ['targetingsubtype','matchtype','subtype']
+  ]
+).map(group=>group.map(token=>token.toLowerCase().replace(/[^a-z0-9]+/g,'')));
+function scoreHeaderRow(headers){
+  if(!Array.isArray(headers) || !headers.length) return 0;
+  let score=0;
+  for(const tokens of HEADER_ROW_SCORE_GROUPS){
+    if(findIndexByTokens(headers,tokens)>-1){
+      score+=1;
+    }
+  }
+  return score;
+}
+function detectHeaderRowIndex(sheetData){
+  if(!Array.isArray(sheetData) || !sheetData.length) return 1;
+  const limit=Math.min(sheetData.length,50);
+  let bestIndex=-1;
+  let bestScore=-1;
+  let bestTextCount=-1;
+  let bestDistinctCount=-1;
+  for(let idx=0; idx<limit; idx++){
+    const row=Array.isArray(sheetData[idx])?sheetData[idx]:[];
+    if(!row || !row.length) continue;
+    const headers=row.map(value=>{
+      if(value==null) return '';
+      const text=typeof value==='string'?value:String(value);
+      return text.trim();
+    });
+    const textCount=headers.filter(Boolean).length;
+    if(!textCount) continue;
+    const distinctCount=new Set(headers.filter(Boolean).map(h=>h.toLowerCase())).size;
+    if(distinctCount<3) continue;
+    const score=scoreHeaderRow(headers);
+    if(
+      score>bestScore ||
+      (score===bestScore && distinctCount>bestDistinctCount) ||
+      (score===bestScore && distinctCount===bestDistinctCount && textCount>bestTextCount)
+    ){
+      bestScore=score;
+      bestIndex=idx;
+      bestTextCount=textCount;
+      bestDistinctCount=distinctCount;
+    }
+  }
+  if(bestIndex>-1) return bestIndex;
+  for(let idx=0; idx<limit; idx++){
+    const row=sheetData[idx];
+    if(!Array.isArray(row)) continue;
+    const headers=row.map(value=>{
+      if(value==null) return '';
+      return String(value).trim();
+    }).filter(Boolean);
+    const distinctCount=new Set(headers.map(h=>h.toLowerCase())).size;
+    if(distinctCount>=3){
+      return idx;
+    }
+  }
+  return 1;
+}
+async function handleLocalFile(e){
+  const f = e.target.files && e.target.files[0];
+  if(!f) return;
+  try{
+    showLoading(true);
+    const buf = await f.arrayBuffer();
+    await loadWorkbookBuffer(buf,{
+      dataset:{
+        type:'local',
+        file:f.name||'local-file',
+        label:f.name||'Local file'
+      }
+    });
+  }catch(err){
+    console.error(err);
+    alert('Failed to parse Excel: '+(err?.message||err));
+    if(!state.hasData) setHasData(false);
+  }finally{
+    showLoading(false);
+    e.target.value='';
+  }
+}
+async function loadWorkbookBuffer(buf, options={}){
+  await parseExcel(buf,{dataset:options?.dataset||null});
+  if(options?.dataset){
+    setActiveDataset(options.dataset);
+  }else if(options){
+    const datasetInfo={
+      type:options.type||'',
+      file:options.file||'',
+      label:options.label||''
+    };
+    if(datasetInfo.type || datasetInfo.file || datasetInfo.label){
+      setActiveDataset(datasetInfo);
+    }
+  }
+  setHasData(true);
+  applyDefaultFiltersForDataset(options?.dataset||null);
+}
+
+async function fetchArrayBufferFromUrl(file){
+  const apiUrl=(()=>{ try{
+    const url=new URL(WORKBOOK_API_ENDPOINT);
+    if(file) url.searchParams.set('name', file);
+    return url.toString();
+  }catch(_){
+    return WORKBOOK_API_ENDPOINT;
+  }})();
+  let apiError=null;
+  if(apiUrl){
+    try{
+      const response=await fetch(apiUrl,{cache:'no-store'});
+      if(response.ok || response.status===0){
+        const contentType=response.headers.get('content-type')||'';
+        if(contentType.includes('text/html')){
+          throw new Error('Received HTML instead of an Excel file. Verify the Excel file path and API URL.');
+        }
+        return response.arrayBuffer();
+      }
+      const status=response.status||'';
+      const statusText=response.statusText||'';
+      const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
+      apiError=new Error(detail||'Unable to fetch dataset');
+    }catch(err){
+      apiError=err;
+    }
+  }
+  if(!file){
+    throw apiError || new Error('Unable to fetch dataset');
+  }
+  if(HAS_EXPLICIT_API_BASE){
+    throw apiError || new Error('Unable to fetch dataset');
+  }
+  let directUrl;
+  try{
+    directUrl=new URL(file, document.baseURI).href;
+  }catch(_){
+    directUrl=encodeURI(file);
+  }
+  const response=await fetch(directUrl,{cache:'no-store'});
+  if(response.ok || response.status===0){
+    const contentType=response.headers.get('content-type')||'';
+    if(contentType.includes('text/html')){
+      throw new Error('Received HTML instead of an Excel file. Verify the Excel file path.');
+    }
+    return response.arrayBuffer();
+  }
+  const status=response.status||'';
+  const statusText=response.statusText||'';
+  const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
+  throw new Error(detail||'Unable to fetch dataset');
+}
+
+async function fetchJsonFromUrl(file){
+  let targetUrl;
+  try{
+    targetUrl=new URL(file, document.baseURI).href;
+  }catch(_){
+    targetUrl=encodeURI(file);
+  }
+  const response=await fetch(targetUrl,{cache:'no-store'});
+  if(!response.ok && response.status!==0){
+    const status=response.status||'';
+    const statusText=response.statusText||'';
+    const detail=[status?`HTTP ${status}`:'',statusText].filter(Boolean).join(' ').trim();
+    throw new Error(detail||'Unable to fetch dataset');
+  }
+  return response.json();
+}
+
+async function loadWorkbookDatasetFromUrl(file,label){
+  const preprocessedFile=getPreprocessedFileForWorkbook(file);
+  if(preprocessedFile){
+    const dataset={
+      type:'workbook',
+      file,
+      label:label || formatDatasetLabelFromFile(file)
+    };
+    try{
+      await loadPreprocessedDatasetFromUrl(preprocessedFile,dataset.label,{dataset});
+      return dataset;
+    }catch(err){
+      console.warn(`Preprocessed dataset load failed (${preprocessedFile}); falling back to workbook.`, err);
+    }
+  }
+  const dataset={
+    type:'workbook',
+    file,
+    label:label || formatDatasetLabelFromFile(file)
+  };
+  const buf=await fetchArrayBufferFromUrl(file);
+  await loadWorkbookBuffer(buf,{dataset});
+  return dataset;
+}
+
+function getPreprocessedFileForWorkbook(file){
+  const key=String(file||'').trim().toLowerCase();
+  return PREPROCESSED_WORKBOOK_MAP[key] || '';
+}
+
+async function loadPreprocessedDatasetFromUrl(file,label,options={}){
+  const payload=await fetchJsonFromUrl(file);
+  const sheetData=Array.isArray(payload?.sheet_data)?payload.sheet_data:null;
+  if(!sheetData || !sheetData.length) throw new Error('Dataset is missing sheet data');
+  const headerRowIndex=Number.isInteger(payload?.header_row_index)?payload.header_row_index:1;
+  await buildStateFromSheetData(sheetData,{headerRowIndex});
+  const datasetOverride=options?.dataset;
+  setActiveDataset(datasetOverride || {
+    type:'preprocessed',
+    file,
+    label:label || formatDatasetLabelFromFile(file)
+  });
+  setHasData(true);
+  return state.dataset;
+}
+
+async function buildStateFromWorksheet(ws, options={}){
+  const SQL = await (sqlReadyPromise || loadSqlLibrary());
+  if(!SQL) throw new Error('Unable to initialize SQL engine');
+  if(!ws || !ws['!ref']) throw new Error('No usable sheet found');
+  const range=XLSX.utils.decode_range(ws['!ref']);
+  const totalRows=range.e.r - range.s.r + 1;
+  if(totalRows < 3) throw new Error('No usable sheet found');
+  const headerRowIndex=Number.isInteger(options?.headerRowIndex)?options.headerRowIndex:1;
+  if(headerRowIndex >= totalRows) throw new Error('No usable sheet found');
+  const headerRows=XLSX.utils.sheet_to_json(ws,{
+    header:1,
+    raw:true,
+    defval:null,
+    dense:true,
+    range:{s:{r:headerRowIndex, c:range.s.c}, e:{r:headerRowIndex, c:range.e.c}}
+  });
+  const headerRow=Array.isArray(headerRows?.[0])?headerRows[0]:[];
+  const headers=headerRow.map(h=>String(h??'').trim());
+  const dataRowTotal=Math.max(range.e.r - headerRowIndex, 0);
+  if(dataRowTotal < 1) throw new Error('No usable sheet found');
+  const progressStep=computeProgressStep(dataRowTotal);
+  let processedRows=0;
+  if(progressStep) updateLoadingProgress(0,dataRowTotal);
+
+  const cols={
+    date:       findIndexByTokens(headers,['date','day','reportingdate']),
+    store:      findIndexByTokens(headers,['store','lo','market','site','locale','country','account']),
+    lo:         findIndexByTokens(headers,['lo','lineofbusiness','lob','store','market']),
+    impressions:findIndexByTokens(headers,['impressions','impr']),
+    clicks:     findIndexByTokens(headers,['clicks']),
+    revenue:    findIndexByTokens(headers,['sales','revenue','totalsales','orderedrevenue','attributedsales']),
+    spend:      findIndexByTokens(headers,['spend','adspend','cost','advertisingcost']),
+    category:   findIndexByTokens(headers,['category','producttype','cat']),
+    ttype:      findIndexByTokens(headers,['targetingtype','adtype','type']),
+    tsub:       findIndexByTokens(headers,['targetingsubtype','matchtype','subtype']),
+    tsub2:      findIndexByTokens(headers,['subtype2','matchtype2']),
+    targeting:  findIndexByTokens(headers,['targeting']),
+    term:       findIndexByTokens(headers,['customersearchterm','searchterm','term']),
+    customerType:findIndexByTokens(headers,['customersearchtermtype','searchtermtype']),
+    targetingAsin:findIndexByTokens(headers,['targetingasin','targetasin','advertisedasin','asin']),
+    targetingCat: findIndexByTokens(headers,['targetingcat','targetcat']),
+    placement:  findIndexByTokens(headers,['placement','placements']),
+    campaign:   findIndexByTokens(headers,['campaignname','campaign']),
+    adgroup:    findIndexByTokens(headers,['adgroupname','ad group name','adgroup']),
+    portfolio:  findIndexByTokens(headers,['portfolioname','portfolio']),
+  };
+  const mapCols={}; for(const [k,idx] of Object.entries(cols)){ if(idx>-1) mapCols[k]={name:headers[idx],idx}; }
+  if(mapCols.store && !mapCols.lo) mapCols.lo = {...mapCols.store, aliasOf:'store'};
+  state.columns=mapCols;
+  if(mapCols.targetingAsin) ensureAsinSkuMap();
+  const numericIdx=new Set([mapCols.impressions?.idx,mapCols.clicks?.idx,mapCols.revenue?.idx,mapCols.spend?.idx].filter(idx=>Number.isInteger(idx)));
+  const usedNames=new Set();
+  const columnInfo=headers.map((header,idx)=>{
+    const normalized=normalize(header);
+    const fallback=`column_${idx+1}`;
+    const sqlName=makeSqlColumnName(normalized,fallback,usedNames);
+    const isDate=mapCols.date && idx===mapCols.date.idx;
+    const type=isDate?'TEXT':(numericIdx.has(idx)?'REAL':'TEXT');
+    return {index:idx, header, normalized, sqlName, type, isDate};
+  });
+  const columnMap=new Map();
+  columnInfo.forEach(info=>{ const key=info.normalized||''; if(!columnMap.has(key)) columnMap.set(key,info); });
+
+  if(state.sql?.db){
+    try{ state.sql.db.close(); }catch(_){ }
+  }
+  const db=new SQL.Database();
+  const tableName='search_terms';
+  const columnDefs=columnInfo.map(info=>`"${info.sqlName}" ${info.type}`);
+  db.exec(`CREATE TABLE "${tableName}" (${columnDefs.join(',')});`);
+  const placeholders=columnInfo.map(()=>'?').join(',');
+  const stmt=db.prepare(`INSERT INTO "${tableName}" VALUES (${placeholders})`);
+  db.exec('BEGIN TRANSACTION;');
+  let rowCount=0;
+  const chunkSize=Number.isInteger(options?.chunkSize)?options.chunkSize:LARGE_SHEET_CHUNK_SIZE;
+  for(let start=headerRowIndex+1; start<=range.e.r; start+=chunkSize){
+    const end=Math.min(start+chunkSize-1, range.e.r);
+    const chunk=XLSX.utils.sheet_to_json(ws,{
+      header:1,
+      raw:true,
+      defval:null,
+      dense:true,
+      range:{s:{r:start, c:range.s.c}, e:{r:end, c:range.e.c}}
+    });
+    if(Array.isArray(chunk)){
+      for(let r=0; r<chunk.length; r++){
+        const rowRaw=Array.isArray(chunk[r])?chunk[r]:[];
+        const rowValues=new Array(columnInfo.length);
+        let hasValue=false;
+        for(let i=0;i<columnInfo.length;i++){
+          const info=columnInfo[i];
+          const rawValue=rowRaw[i];
+          let v=rawValue;
+          if(info.isDate){
+            let dateVal=null;
+            if(rawValue instanceof Date){
+              dateVal=rawValue;
+            }else if(typeof rawValue==='number'){
+              const parsed=XLSX?.SSF?.parse_date_code ? XLSX.SSF.parse_date_code(rawValue) : null;
+              dateVal=(parsed&&parsed.y)?new Date(parsed.y,parsed.m-1,parsed.d):null;
+            }else if(typeof rawValue==='string' && rawValue){
+              const trimmed=rawValue.trim();
+              if(trimmed){
+                const numericText=trimmed.replace(/,/g,'');
+                if(/^[-+]?\\d+(?:\\.\\d+)?$/.test(numericText)){
+                  const asNumber=Number(numericText);
+                  if(Number.isFinite(asNumber)){
+                    const parsed=XLSX?.SSF?.parse_date_code ? XLSX.SSF.parse_date_code(asNumber) : null;
+                    if(parsed && parsed.y){
+                      dateVal=new Date(parsed.y,parsed.m-1,parsed.d);
+                    }
+                  }
+                }
+              }
+              if(!dateVal){
+                const parsed=parseInputDate(trimmed) || (isNaN(+new Date(trimmed))?null:new Date(trimmed));
+                dateVal=parsed instanceof Date?parsed:null;
+              }
+            }
+            v=dateVal instanceof Date?toInputDate(dateVal):null;
+          }else if(numericIdx.has(i)){
+            v=parseNumber(rawValue);
+          }else{
+            v=rawValue==null?'':String(rawValue).trim();
+          }
+          if(info.isDate && !v) v=null;
+          rowValues[i]=v;
+          if(v!=='' && v!=null) hasValue=true;
+        }
+        if(!hasValue) continue;
+        const prepared=rowValues.map(value=>value===undefined?null:value);
+        stmt.run(prepared);
+        rowCount+=1;
+      }
+    }
+    processedRows+=end-start+1;
+    if(progressStep && (processedRows%progressStep===0 || processedRows>=dataRowTotal)){
+      updateLoadingProgress(Math.min(processedRows,dataRowTotal),dataRowTotal);
+      await yieldForHeavyWork();
+    }
+  }
+  updateLoadingProgress(dataRowTotal,dataRowTotal);
+  await yieldForHeavyWork();
+  stmt.free();
+  db.exec('COMMIT;');
+
+  state.sql={db, table:tableName, columns:columnInfo, columnMap, rowCount};
+  state.rows=[];
+  state.monthSel.clear();
+  resetConversionPaging();
+  buildSqlIndexes();
+  buildMonths();
+  const {token:filterToken, remainingKeys}=initFilters({initialKeys:INITIAL_FILTER_KEYS});
+  renderAll();
+  if(Array.isArray(remainingKeys) && remainingKeys.length){
+    scheduleDeferredFilterBuild(remainingKeys, filterToken);
+  }
+}
+
+function resolvePreferredSheetName(wb){
+  if(!wb || !Array.isArray(wb.SheetNames) || !wb.SheetNames.length) return null;
+  const sheetNames=wb.SheetNames;
+  const normalizedSheetNames=sheetNames.map(name=>String(name).trim());
+  const normalizedLookup=new Map(
+    normalizedSheetNames.map((name, idx)=>[name.toLowerCase(), sheetNames[idx]])
+  );
+  const priorityNames=['Brands Campaign','Sheet1','Sheet 1'];
+  for(const name of priorityNames){
+    const match=normalizedLookup.get(name.toLowerCase());
+    if(match) return match;
+  }
+  return sheetNames[0];
+}
+
+function getWorksheetRowCount(ws){
+  if(!ws || !ws['!ref']) return 0;
+  const range=XLSX.utils.decode_range(ws['!ref']);
+  return Math.max(range.e.r - range.s.r + 1, 0);
+}
+
+function getWorkbookSheetDiagnostics(wb){
+  return (wb?.SheetNames||[]).map(name=>({
+    name,
+    rowCount:getWorksheetRowCount(wb?.Sheets?.[name])
+  }));
+}
+
+async function tryParseWorksheet(wb, sheetName, options){
+  const ws=wb?.Sheets?.[sheetName];
+  if(!ws || !ws['!ref']) return {sheetName, error:'empty'};
+  const parseOptions=options.parseOptions;
+  const parseFallbackOptions=options.parseFallbackOptions;
+  const headerRowCandidates=options.headerRowCandidates;
+  const sheetRange=XLSX.utils.decode_range(ws['!ref']);
+  const sheetRowCount=getWorksheetRowCount(ws);
+  let sheetData=null;
+  if(sheetRowCount > LARGE_SHEET_ROW_THRESHOLD){
+    const fallbackSampleRange={
+      s:{r:sheetRange.s.r ?? 0,c:sheetRange.s.c ?? 0},
+      e:{r:Math.min((sheetRange.s.r ?? 0)+24, sheetRange.e.r ?? 24), c:sheetRange.e.c ?? 0}
+    };
+    const headerRowIndex=Number.isInteger(headerRowCandidates.get(sheetName))
+      ? headerRowCandidates.get(sheetName)
+      : detectHeaderRowIndex(XLSX.utils.sheet_to_json(ws,{
+        ...parseOptions,
+        range:fallbackSampleRange
+      })) + (fallbackSampleRange.s.r || 0);
+    try{
+      await buildStateFromWorksheet(ws,{headerRowIndex});
+      return {sheetName, ws};
+    }catch(err){
+      const message=String(err?.message||err);
+      if(!message.includes('No usable sheet found')) throw err;
+      console.warn(`Large sheet parse failed for "${sheetName}"; falling back to full parse.`, err);
+    }
+  }
+  sheetData=XLSX.utils.sheet_to_json(ws, parseOptions);
+  if(!Array.isArray(sheetData) || sheetData.length<3){
+    sheetData=XLSX.utils.sheet_to_json(ws, parseFallbackOptions);
+  }
+  if(!Array.isArray(sheetData) || sheetData.length<3){
+    return {sheetName, error:'empty'};
+  }
+  const headerRowIndex=detectHeaderRowIndex(sheetData);
+  await buildStateFromSheetData(sheetData,{headerRowIndex});
+  return {sheetName, ws};
+}
+
+async function parseWorkbook(wb, options={}){
+  const sheetNames=Array.isArray(wb?.SheetNames)?wb.SheetNames:[];
+  if(!sheetNames.length){
+    throw new Error('No worksheets found. Available sheets: none.');
+  }
+  const preferredSheet=resolvePreferredSheetName(wb);
+  let best=null,score=-1,bestTextCount=-1;
+  const headerRowCandidates=new Map();
+  const parseOptions={header:1, raw:true, defval:null, dense:true};
+  const parseFallbackOptions={header:1, raw:false, defval:null, dense:false, blankrows:true};
+  const sheetNamesToScan=preferredSheet?[preferredSheet]:sheetNames;
+  for(const name of sheetNamesToScan){
+    const ws=wb.Sheets[name];
+    if(!ws) continue;
+    const ref=ws['!ref'];
+    if(!ref) continue;
+    const range=XLSX.utils.decode_range(ref);
+    const sampleRange={
+      s:{r:range.s.r,c:range.s.c},
+      e:{r:Math.min(range.s.r+24, range.e.r), c:range.e.c}
+    };
+    const sample=XLSX.utils.sheet_to_json(ws,{
+      ...parseOptions,
+      range:sampleRange
+    });
+    if(!sample || !sample.length) continue;
+    const headerRowIndex=detectHeaderRowIndex(sample);
+    const absoluteHeaderRowIndex=headerRowIndex + (sampleRange.s.r || 0);
+    headerRowCandidates.set(name, absoluteHeaderRowIndex);
+    const headers=Array.isArray(sample[headerRowIndex])?sample[headerRowIndex]:[];
+    const normalizedHeaders=headers.map(value=>String(value??'').trim());
+    const textCount=normalizedHeaders.filter(Boolean).length;
+    const s=scoreHeaderRow(normalizedHeaders);
+    if(
+      s>score ||
+      (s===score && textCount>bestTextCount)
+    ){
+      score=s;
+      best=name;
+      bestTextCount=textCount;
+    }
+  }
+  const diagnostics=getWorkbookSheetDiagnostics(wb);
+  const fallbackNames=diagnostics
+    .slice()
+    .sort((a,b)=>b.rowCount - a.rowCount)
+    .map(entry=>entry.name);
+  const candidates=[
+    preferredSheet,
+    best,
+    ...fallbackNames
+  ].filter((name, idx, arr)=>name && arr.indexOf(name)===idx);
+  if(!candidates.length) throw new Error('No usable sheet found');
+  const parseContext={parseOptions, parseFallbackOptions, headerRowCandidates};
+  for(const name of candidates){
+    const result=await tryParseWorksheet(wb, name, parseContext);
+    if(!result?.error){
+      return;
+    }
+    console.warn(`Sheet "${name}" is missing or empty; trying next worksheet.`);
+  }
+  const available=diagnostics.map(entry=>entry.name).filter(Boolean);
+  const detail=available.length?` Available sheets: ${available.join(', ')}.`:'';
+  throw new Error(`No usable sheet found.${detail}`);
+}
+
+async function parseExcel(buf, options={}){
+  const baseOptions={ type:'array', cellDates:true, cellNF:false, cellText:false, dense:true };
+  try{
+    const wb = XLSX.read(buf, baseOptions);
+    await parseWorkbook(wb, options);
+    return;
+  }catch(err){
+    const message=String(err?.message||err);
+    if(!message.includes('No usable sheet found')) throw err;
+  }
+  const wb = XLSX.read(buf, { ...baseOptions, cellText:true, dense:false });
+  await parseWorkbook(wb, options);
+}
+
+async function buildStateFromSheetData(sheetData, options={}){
+  const SQL = await (sqlReadyPromise || loadSqlLibrary());
+  if(!SQL) throw new Error('Unable to initialize SQL engine');
+  if(!Array.isArray(sheetData) || sheetData.length<3) throw new Error('No usable sheet found');
+  const headerRowIndex=Number.isInteger(options?.headerRowIndex)?options.headerRowIndex:1;
+  const headerRow=Array.isArray(sheetData[headerRowIndex])?sheetData[headerRowIndex]:[];
+  const headers=headerRow.map(h=>String(h??'').trim());
+  const dataRowsRaw=sheetData.slice(headerRowIndex+1);
+  const totalRows=dataRowsRaw.length;
+  const progressStep=computeProgressStep(totalRows);
+  let processedRows=0;
+  if(progressStep) updateLoadingProgress(0,totalRows);
+
+  const cols={
+    date:       findIndexByTokens(headers,['date','day','reportingdate']),
+    store:      findIndexByTokens(headers,['store','lo','market','site','locale','country','account']),
+    lo:         findIndexByTokens(headers,['lo','lineofbusiness','lob','store','market']),
+    impressions:findIndexByTokens(headers,['impressions','impr']),
+    clicks:     findIndexByTokens(headers,['clicks']),
+    revenue:    findIndexByTokens(headers,['sales','revenue','totalsales','orderedrevenue','attributedsales']),
+    spend:      findIndexByTokens(headers,['spend','adspend','cost','advertisingcost']),
+    category:   findIndexByTokens(headers,['category','producttype','cat']),
+    ttype:      findIndexByTokens(headers,['targetingtype','adtype','type']),
+    tsub:       findIndexByTokens(headers,['targetingsubtype','matchtype','subtype']),
+    tsub2:      findIndexByTokens(headers,['subtype2','matchtype2']),
+    targeting:  findIndexByTokens(headers,['targeting']),
+    term:       findIndexByTokens(headers,['customersearchterm','searchterm','term']),
+    customerType:findIndexByTokens(headers,['customersearchtermtype','searchtermtype']),
+    targetingAsin:findIndexByTokens(headers,['targetingasin','targetasin','advertisedasin','asin']),
+    targetingCat: findIndexByTokens(headers,['targetingcat','targetcat']),
+    placement:  findIndexByTokens(headers,['placement','placements']),
+    campaign:   findIndexByTokens(headers,['campaignname','campaign']),
+    adgroup:    findIndexByTokens(headers,['adgroupname','ad group name','adgroup']),
+    portfolio:  findIndexByTokens(headers,['portfolioname','portfolio']),
+  };
+  const mapCols={}; for(const [k,idx] of Object.entries(cols)){ if(idx>-1) mapCols[k]={name:headers[idx],idx}; }
+  if(mapCols.store && !mapCols.lo) mapCols.lo = {...mapCols.store, aliasOf:'store'}; // fallback
+  state.columns=mapCols;
+  if(mapCols.targetingAsin) ensureAsinSkuMap();
+  const numericIdx=new Set([mapCols.impressions?.idx,mapCols.clicks?.idx,mapCols.revenue?.idx,mapCols.spend?.idx].filter(idx=>Number.isInteger(idx)));
+  const usedNames=new Set();
+  const columnInfo=headers.map((header,idx)=>{
+    const normalized=normalize(header);
+    const fallback=`column_${idx+1}`;
+    const sqlName=makeSqlColumnName(normalized,fallback,usedNames);
+    const isDate=mapCols.date && idx===mapCols.date.idx;
+    const type=isDate?'TEXT':(numericIdx.has(idx)?'REAL':'TEXT');
+    return {index:idx, header, normalized, sqlName, type, isDate};
+  });
+  const columnMap=new Map();
+  columnInfo.forEach(info=>{ const key=info.normalized||''; if(!columnMap.has(key)) columnMap.set(key,info); });
+
+  if(state.sql?.db){
+    try{ state.sql.db.close(); }catch(_){ }
+  }
+  const db=new SQL.Database();
+  const tableName='search_terms';
+  const columnDefs=columnInfo.map(info=>`"${info.sqlName}" ${info.type}`);
+  db.exec(`CREATE TABLE "${tableName}" (${columnDefs.join(',')});`);
+  const placeholders=columnInfo.map(()=>'?').join(',');
+  let stmt=null;
+  let transactionStarted=false;
+  let rowCount=0;
+  for(let r=0;r<dataRowsRaw.length;r++){
+    processedRows+=1;
+    const rowRaw=Array.isArray(dataRowsRaw[r])?dataRowsRaw[r]:[];
+    const rowValues=new Array(columnInfo.length);
+    let hasValue=false;
+    for(let i=0;i<columnInfo.length;i++){
+      const info=columnInfo[i];
+      const rawValue=rowRaw[i];
+      let v=rawValue;
+      if(info.isDate){
+        let dateVal=null;
+        if(rawValue instanceof Date){
+          dateVal=rawValue;
+        }else if(typeof rawValue==='number'){
+          const parsed=XLSX?.SSF?.parse_date_code ? XLSX.SSF.parse_date_code(rawValue) : null;
+          dateVal=(parsed&&parsed.y)?new Date(parsed.y,parsed.m-1,parsed.d):null;
+        }else if(typeof rawValue==='string' && rawValue){
+          const trimmed=rawValue.trim();
+          if(trimmed){
+            const numericText=trimmed.replace(/,/g,'');
+            if(/^[-+]?\d+(?:\.\d+)?$/.test(numericText)){
+              const asNumber=Number(numericText);
+              if(Number.isFinite(asNumber)){
+                const parsed=XLSX?.SSF?.parse_date_code ? XLSX.SSF.parse_date_code(asNumber) : null;
+                if(parsed && parsed.y){
+                  dateVal=new Date(parsed.y,parsed.m-1,parsed.d);
+                }
+              }
+            }
+            if(!dateVal){
+              const parsed=parseInputDate(trimmed) || (isNaN(+new Date(trimmed))?null:new Date(trimmed));
+              dateVal=parsed instanceof Date?parsed:null;
+            }
+          }
+        }
+        v=dateVal instanceof Date?toInputDate(dateVal):null;
+      }else if(numericIdx.has(i)){
+        v=parseNumber(rawValue);
+      }else{
+        v=rawValue==null?'':String(rawValue).trim();
+      }
+      if(info.isDate && !v) v=null;
+      rowValues[i]=v;
+      if(v!=='' && v!=null) hasValue=true;
+    }
+    if(!hasValue) continue;
+    if(!stmt){
+      stmt=db.prepare(`INSERT INTO "${tableName}" VALUES (${placeholders})`);
+    }
+    if(!transactionStarted){
+      db.exec('BEGIN TRANSACTION;');
+      transactionStarted=true;
+    }
+    const prepared=rowValues.map(value=>value===undefined?null:value);
+    stmt.run(prepared);
+    rowCount+=1;
+    if(progressStep && (processedRows%progressStep===0 || processedRows===totalRows)){
+      updateLoadingProgress(processedRows,totalRows);
+      await yieldForHeavyWork();
+    }
+  }
+  if(progressStep){
+    updateLoadingProgress(totalRows,totalRows);
+    await yieldForHeavyWork();
+  }
+  if(stmt){
+    stmt.free();
+  }
+  if(transactionStarted){
+    db.exec('COMMIT;');
+  }
+
+  state.sql={db, table:tableName, columns:columnInfo, columnMap, rowCount};
+  state.rows=[];
+  state.monthSel.clear();
+  resetConversionPaging();
+  buildSqlIndexes();
+  buildMonths();
+  const {token:filterToken, remainingKeys}=initFilters({initialKeys:INITIAL_FILTER_KEYS});
+  renderAll();
+  if(Array.isArray(remainingKeys) && remainingKeys.length){
+    scheduleDeferredFilterBuild(remainingKeys, filterToken);
+  }
+}
+
+function applyDefaultFiltersForDataset(datasetInfo){
+  if(!state.hasData) return false;
+  const info=datasetInfo || state.dataset || {};
+  const file=(info.file||'').toLowerCase();
+  const label=(info.label||'').toLowerCase();
+  const customerTypeLabel=(state.columns?.customerType?.name||'').toLowerCase();
+  const termLabel=(state.columns?.term?.name||'').toLowerCase();
+  const looksLikeSearchTerms =
+    file.includes('search term') ||
+    label.includes('search term') ||
+    (customerTypeLabel.includes('customer search term') && termLabel.includes('search term'));
+  if(!looksLikeSearchTerms) return false;
+
+  const applySelection=(key, values)=>{
+    const root=el.dd?.[key];
+    const col=state.columns?.[key];
+    if(!root || !col || col.aliasOf) return false;
+    return setFilterSelections(root, values, true);
+  };
+
+  let changed=false;
+  if(applySelection('customerType',['ST'])) changed=true;
+  if(applySelection('tsub',['Keyword'])) changed=true;
+
+  if(changed){
+    updateAllFilterOptions(null);
+    resetConversionPaging();
+    renderAll();
+    updateResetButtonVisibility();
+  }
+  return changed;
+}
+
+function buildSqlIndexes(){
+  const db=getSqlDb();
+  if(!db || !state.sql?.table) return;
+  const table=state.sql.table;
+  const keys=['date','store','lo','category','campaign','adgroup','portfolio','term','customerType','ttype','tsub','tsub2','placement','targeting','targetingAsin','targetingCat'];
+  keys.forEach(key=>{
+    const info=getSqlInfoForStateKey(key);
+    if(!info) return;
+    const indexName=`idx_${table}_${info.sqlName}`;
+    try{
+      db.exec(`CREATE INDEX IF NOT EXISTS "${indexName}" ON "${table}"("${info.sqlName}")`);
+    }catch(err){
+      console.warn('Index creation failed:', indexName, err);
+    }
+  });
+}
+
+/* ===== months & filters ===== */
+function buildMonths(){
+  state.monthDirty=false;
+  const db=getSqlDb();
+  const dateInfo=getSqlInfoForStateKey('date');
+  if(!db || !dateInfo){
+    state.monthOptions=[];
+    state.dateBounds={min:null,max:null};
+    clearCustomRange({skipRender:true, skipFilters:true});
+    el.monthsWrap.hidden=true;
+    syncCustomRangeInputs();
+    updateMonthSummary();
+    return;
+  }
+
+  const table=state.sql.table;
+  const bounds=sqlQueryAll(`SELECT MIN("${dateInfo.sqlName}") AS minDate, MAX("${dateInfo.sqlName}") AS maxDate FROM "${table}" WHERE "${dateInfo.sqlName}" IS NOT NULL AND "${dateInfo.sqlName}" <> ''`)[0] || {};
+  const minDateStr=bounds.minDate||null;
+  const maxDateStr=bounds.maxDate||null;
+  const minDate=minDateStr?parseInputDate(minDateStr):null;
+  const maxDate=maxDateStr?parseInputDate(maxDateStr):null;
+  state.dateBounds={min:minDate,max:maxDate};
+
+  const monthRows=sqlQueryAll(`SELECT substr("${dateInfo.sqlName}",1,7) AS ym, COUNT(*) AS c FROM "${table}" WHERE "${dateInfo.sqlName}" IS NOT NULL AND "${dateInfo.sqlName}" <> '' GROUP BY ym ORDER BY ym`);
+  const monthOptions=monthRows.filter(row=>row.ym).map(row=>{
+    const ym=String(row.ym);
+    const year=ym.slice(0,4);
+    const monthIndex=Number(ym.slice(5))-1;
+    const monthName=MONTH_NAMES[monthIndex]||ym;
+    return {ym, year, monthIndex, label:monthName, shortLabel:monthName};
+  });
+  state.monthOptions=monthOptions;
+
+  const yearGroups=new Map();
+  monthOptions.forEach(opt=>{
+    if(!yearGroups.has(opt.year)) yearGroups.set(opt.year, []);
+    yearGroups.get(opt.year).push(opt);
+  });
+
+  el.monthList.innerHTML=Array.from(yearGroups.entries()).map(([year, months])=>{
+    const monthRowsHtml=months.map(o=>`
+        <label class="month-row">
+          <input type="checkbox" value="${o.ym}" ${state.monthSel.has(o.ym)?'checked':''}/>
+          <span class="month-name">${escapeHtml(o.shortLabel)}</span>
+        </label>`).join('');
+    return `
+      <div class="month-year-group" data-year="${escapeHtml(year)}">
+        <div class="month-year-row">
+          <button type="button" class="month-year-toggle" aria-expanded="false" aria-label="Show ${escapeHtml(year)} months">+</button>
+          <span class="month-year-label">${escapeHtml(year)}</span>
+        </div>
+        <div class="month-year-months" data-year-months="${escapeHtml(year)}" hidden>
+          ${monthRowsHtml}
+        </div>
+      </div>`;
+  }).join('');
+
+  el.monthList.querySelectorAll('.month-year-toggle').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const group=btn.closest('.month-year-group');
+      if(!group) return;
+      const year=group.getAttribute('data-year');
+      const currentPanel=group.querySelector('.month-year-months');
+      const willOpen=!!currentPanel?.hidden;
+      el.monthList.querySelectorAll('.month-year-months').forEach(panel=>{
+        const isTarget=panel.getAttribute('data-year-months')===year;
+        panel.hidden=!(isTarget && willOpen);
+      });
+      el.monthList.querySelectorAll('.month-year-toggle').forEach(toggle=>{
+        const toggleGroup=toggle.closest('.month-year-group');
+        const isOpen=willOpen && toggleGroup?.getAttribute('data-year')===year;
+        toggle.classList.toggle('is-open', isOpen);
+        toggle.textContent=isOpen ? '-' : '+';
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        const labelYear=toggleGroup?.getAttribute('data-year') || year;
+        toggle.setAttribute('aria-label', `${isOpen ? 'Hide' : 'Show'} ${labelYear} months`);
+      });
+    });
+  });
+
+  el.monthList.querySelectorAll('input[type=checkbox]').forEach(cb=>{
+    cb.addEventListener('change', ()=>{
+      if(cb.checked) state.monthSel.add(cb.value);
+      else state.monthSel.delete(cb.value);
+      state.monthDirty=true;
+      if(state.customRange.active) deactivateCustomRange();
+      updateMonthSummary();
+      updateResetButtonVisibility();
+    });
+  });
+  const customBtn=el.monthTabList?.querySelector('button[data-tab="custom"]');
+  if(customBtn){
+    const disabled=!state.dateBounds.min || !state.dateBounds.max;
+    customBtn.disabled=disabled;
+    if(disabled) customBtn.setAttribute('aria-disabled','true');
+    else customBtn.removeAttribute('aria-disabled');
+  }
+  syncCustomRangeInputs();
+  state.monthTab = state.customRange.active ? 'custom' : 'months';
+  updateMonthTabs();
+  updateMonthSummary();
+  el.monthsWrap.hidden=state.monthOptions.length===0 && !state.customRange.active;
+  updateDatasetMeta();
+}
+function updateMonthSummary(){
+  const sumEl=el.monthDD.querySelector('.dd-summary');
+  if(!sumEl) return;
+  if(state.customRange.active){
+    const {start,end}=state.customRange;
+    if(start && end) sumEl.textContent=`${toDMY(start)} – ${toDMY(end)}`;
+    else if(start) sumEl.textContent=`From ${toDMY(start)}`;
+    else if(end) sumEl.textContent=`Until ${toDMY(end)}`;
+    else sumEl.textContent='Custom range';
+    return;
+  }
+  const n=state.monthSel.size;
+  if(n===0){ sumEl.textContent='Date Range'; }
+  else if(n===1){ const k=[...state.monthSel][0]; sumEl.textContent=(state.monthOptions.find(o=>o.ym===k)||{}).shortLabel||k; }
+  else { sumEl.textContent=`${n} months`; }
+}
+function applyMonthFilters(force=false){
+  if(!state.hasData) return;
+  state.monthTab = state.customRange.active ? 'custom' : 'months';
+  updateMonthTabs();
+  if(force || state.monthDirty){
+    state.monthDirty=false;
+    updateAllFilterOptions(null);
+    resetConversionPaging();
+    renderAll();
+  }
+  updateResetButtonVisibility();
+}
+
+function hasActiveFilters(){
+  if(!state.hasData) return false;
+  if(state.monthSel.size) return true;
+  if(state.customRange.active) return true;
+  for(const root of Object.values(el.dd||{})){
+    if(!root) continue;
+    if(root.querySelector('.dd-list input[type=checkbox]:checked')) return true;
+  }
+  return false;
+}
+
+function updateResetButtonVisibility(){
+  if(!el.resetFiltersBtn) return;
+  el.resetFiltersBtn.style.display = hasActiveFilters() ? 'inline-flex' : 'none';
+}
+
+
+/* dropdowns */
+function getFilterKey(root){
+  if(!root) return '';
+  const wrapper=root.closest?.('[data-col-wrapper]');
+  return wrapper ? (wrapper.getAttribute('data-col-wrapper') || '') : '';
+}
+
+function ddBuild(root){
+  const isSearchMode=root.classList.contains('dd-search-mode');
+  if(isSearchMode){
+    const wrapper=root.closest('[data-col-wrapper]');
+    const labelNode=wrapper?.querySelector('[data-col-label]');
+    const labelText=labelNode?labelNode.textContent.trim():'';
+    const rawPlaceholder=root.getAttribute('data-placeholder');
+    const placeholder=computeSearchPlaceholder(labelText, rawPlaceholder);
+    const safePlaceholder=escapeHtml(placeholder);
+    root.innerHTML = `
+      <div class="dd-search-shell">
+        <input type="search" class="dd-search" placeholder="${safePlaceholder}" autocomplete="off" aria-label="${safePlaceholder}"/>
+      </div>
+      <div class="dd-panel" hidden>
+        <div class="dd-head dd-search-head">
+          <label class="select-all"><input type="checkbox" class="dd-select-all"/><span>Select all</span></label>
+        </div>
+        <div class="dd-list"></div>
+        <div class="dd-empty">No results</div>
+      </div>`;
+  }else{
+    root.innerHTML = `
+      <div class="dd-control"><span class="dd-summary">All</span><span class="dd-chev">▾</span></div>
+      <div class="dd-panel">
+        <div class="dd-head">
+          <label class="select-all"><input type="checkbox" class="dd-select-all"/><span>Select All</span></label>
+          <input type="search" class="dd-search" placeholder="Type to search"/>
+          <div class="rc">Record Count</div>
+        </div>
+        <div class="dd-list"></div>
+        <div class="dd-empty">No results</div>
+      </div>`;
+  }
+  const panel=root.querySelector('.dd-panel');
+  if(!panel) return;
+  panel.addEventListener('click', (e)=> e.stopPropagation());
+  if(isSearchMode){
+    panel.addEventListener('mousedown', e=>e.preventDefault());
+  }
+  const searchEl=root.querySelector('.dd-search');
+  if(searchEl){
+    const handleSearch=()=>ddApplySearchFilter(root);
+    searchEl.addEventListener('input', handleSearch);
+    searchEl.addEventListener('search', handleSearch);
+    if(isSearchMode){
+      searchEl.addEventListener('focus', ()=>ddApplySearchFilter(root));
+      searchEl.addEventListener('blur', ()=>{
+        setTimeout(()=>{
+          if(root.contains(document.activeElement)) return;
+          root.classList.remove('open');
+          panel.hidden=true;
+          panel.setAttribute('hidden','');
+        },120);
+      });
+      searchEl.addEventListener('keydown', (ev)=>{
+        if(ev.key==='Escape'){
+          if(searchEl.value){
+            searchEl.value='';
+            ddApplySearchFilter(root);
+          }
+          root.classList.remove('open');
+          panel.hidden=true;
+          panel.setAttribute('hidden','');
+          searchEl.blur();
+        }
+      });
+    }
+  }
+  if(!isSearchMode){
+    const control=root.querySelector('.dd-control');
+    if(control){
+      control.addEventListener('click', ()=>{
+        const willOpen=!root.classList.contains('open');
+        document.querySelectorAll('.dd.open').forEach(n=>{
+          n.classList.remove('open');
+          const otherPanel=n.querySelector('.dd-panel');
+          if(otherPanel){
+            otherPanel.hidden=true;
+            otherPanel.setAttribute('hidden','');
+          }
+        });
+        root.classList.toggle('open', willOpen);
+        if(willOpen){
+          panel.hidden=false;
+          panel.removeAttribute('hidden');
+          clampPanelRight(panel);
+          const search=root.querySelector('.dd-search');
+          if(search){
+            search.focus();
+            ddApplySearchFilter(root);
+          }
+        }else{
+          panel.hidden=true;
+          panel.setAttribute('hidden','');
+        }
+      });
+    }
+  }
+  const selectAll=root.querySelector('.dd-select-all');
+  if(selectAll){
+    selectAll.addEventListener('change', (e)=>{
+      const on=e.target.checked;
+      const vis=root.querySelectorAll('.dd-item:not([hidden]) input[type=checkbox]');
+      vis.forEach(cb=>cb.checked=on);
+      ddUpdateSummary(root);
+      ddSyncSelectAll(root);
+      if(isSearchMode){
+        ddRefreshSearchSelections(root);
+        const key=getFilterKey(root);
+        if(key==='sku'){
+          onSkuFilterSelectionChange(true);
+        }else if(state.hasData){
+          updateAllFilterOptions(root);
+          resetConversionPaging();
+          renderAll();
+          updateResetButtonVisibility();
+        }
+      }
+    });
+  }
+  if(isSearchMode){
+    ddUpdateSummary(root);
+    panel.hidden=true;
+    panel.setAttribute('hidden','');
+  }
+}
+function ddSetOptions(root, items, keepSel=true){
+  if(!root.querySelector('.dd-panel')) ddBuild(root);
+  const list=root.querySelector('.dd-list');
+  const filterKey=getFilterKey(root);
+  const prevSel = keepSel ? new Set(ddGetSelected(root)) : new Set();
+  list.innerHTML = items.map(({v,count})=>`
+    <div class="dd-item" title="${escapeHtml(v)}">
+      <label class="dd-left">
+        <input type="checkbox" value="${escapeHtml(v)}" ${prevSel.has(String(v))?'checked':''}/>
+        <span class="dd-text">${escapeHtml(v)}</span>
+      </label>
+      <button type="button" class="dd-only" data-val="${escapeHtml(v)}">ONLY</button>
+      <div class="dd-count">${(count??0).toLocaleString()}</div>
+    </div>`).join('');
+  list.querySelectorAll('.dd-only').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const val=btn.getAttribute('data-val');
+      root.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=(cb.value===val));
+      ddUpdateSummary(root);
+      ddSyncSelectAll(root);
+      ddRefreshSearchSelections(root);
+      if(root.classList.contains('dd-search-mode')){
+        if(filterKey==='sku'){
+          onSkuFilterSelectionChange(true);
+        }else{
+          ddApplyImmediateFilters(root);
+        }
+      }else{
+        if(filterKey==='targetingAsin'){
+          onAsinFilterSelectionChange();
+        }
+        refreshLinkedFilterOptions(root);
+      }
+      const panel=root.querySelector('.dd-panel');
+      if(panel){
+        panel.hidden=true;
+        panel.setAttribute('hidden','');
+      }
+      root.classList.remove('open');
+    });
+  });
+  list.querySelectorAll('input[type=checkbox]').forEach(cb=>{
+    cb.addEventListener('change', ()=>{
+      ddUpdateSummary(root);
+      ddSyncSelectAll(root);
+      ddRefreshSearchSelections(root);
+      if(filterKey==='sku'){
+        onSkuFilterSelectionChange(true);
+      }else if(root.classList.contains('dd-search-mode')){
+        ddApplyImmediateFilters(root);
+      }else{
+        if(filterKey==='targetingAsin'){
+          onAsinFilterSelectionChange();
+        }
+        refreshLinkedFilterOptions(root);
+      }
+    });
+  });
+  ddApplySearchFilter(root);
+  ddUpdateSummary(root);
+  ddRefreshSearchSelections(root);
+}
+function ddGetSelected(root){ return Array.from(root.querySelectorAll('.dd-list input[type=checkbox]:checked')).map(cb=>cb.value); }
+function computeSearchPlaceholder(labelText, fallback){
+  const primary=String(labelText||'').trim();
+  if(primary){
+    return primary.toLowerCase().includes('search') ? primary : `Search ${primary}`;
+  }
+  const secondary=String(fallback||'').trim();
+  if(secondary){
+    return secondary.toLowerCase().includes('search') ? secondary : `Search ${secondary}`;
+  }
+  return 'Search';
+}
+function refreshLinkedFilterOptions(root){
+  if(!root || root.classList.contains('dd-search-mode')) return;
+  if(!state.hasData) return;
+  updateAllFilterOptions(root);
+  if(state.activePivotModal) return;
+  const isMainFilter = !!root.closest?.('#filtersSection');
+  if(isMainFilter){
+    return;
+  }
+  resetConversionPaging();
+  renderAll();
+  updateResetButtonVisibility();
+}
+function ddApplyImmediateFilters(root){
+  if(!root?.classList?.contains('dd-search-mode')) return;
+  if(!state.hasData) return;
+  updateAllFilterOptions(root);
+  resetConversionPaging();
+  renderAll();
+  updateResetButtonVisibility();
+}
+function ddRefreshSearchSelections(root){
+  if(!root?.classList?.contains('dd-search-mode')) return;
+  root.querySelectorAll('.dd-item').forEach(item=>{
+    const cb=item.querySelector('input[type=checkbox]');
+    item.classList.toggle('is-selected', !!cb?.checked);
+  });
+}
+function ddUpdateSummary(root){
+  if(!root) return;
+  const summary=root.querySelector('.dd-summary');
+  if(!summary) return;
+  const sel = ddGetSelected(root);
+  const allLabel = root.classList.contains('dd-search-mode') ? 'All terms' : 'All';
+  summary.textContent = sel.length===0 ? allLabel : sel.length===1 ? sel[0] : `${sel.length} selected`;
+  if(summary.classList.contains('dd-search-summary')){
+    summary.dataset.state = sel.length ? 'active' : 'all';
+  }
+}
+function ddSyncSelectAll(root){
+  if(!root) return;
+  const selectAll=root.querySelector('.dd-select-all');
+  if(!selectAll) return;
+  const vis=Array.from(root.querySelectorAll('.dd-item:not([hidden]) input[type=checkbox]'));
+  selectAll.checked = (vis.length && vis.every(cb=>cb.checked));
+}
+function ddApplySearchFilter(root){
+  if(!root) return;
+  const searchEl=root.querySelector('.dd-search');
+  const q=searchEl ? searchEl.value.trim().toLowerCase() : '';
+  let matches=0;
+  root.querySelectorAll('.dd-item').forEach(item=>{
+    const text=item.querySelector('.dd-text');
+    const txt=text?text.textContent.toLowerCase():'';
+    const show=!q || txt.includes(q);
+    item.hidden=!show;
+    if(show) matches++;
+  });
+  root.classList.toggle('no-results', matches===0);
+  ddSyncSelectAll(root);
+  if(root.classList.contains('dd-search-mode')){
+    const panel=root.querySelector('.dd-panel');
+    if(panel){
+      const active=document.activeElement===searchEl;
+      const query=searchEl?searchEl.value.trim():'';
+      const shouldOpen=active && query.length>0;
+      if(shouldOpen){
+        if(panel.hidden){
+          panel.hidden=false;
+          panel.removeAttribute('hidden');
+        }
+        if(!root.classList.contains('open')){
+          root.classList.add('open');
+          clampPanelRight(panel);
+        }
+      }else{
+        if(!panel.hidden){
+          panel.hidden=true;
+        }
+        panel.setAttribute('hidden','');
+        root.classList.remove('open');
+      }
+    }
+    ddRefreshSearchSelections(root);
+  }
+}
+
+function syncFilterLabels(){
+  const labels=document.querySelectorAll('[data-col-label]');
+  labels.forEach(label=>{
+    const key=label.getAttribute('data-col-label');
+    if(!key) return;
+    const fallback=label.getAttribute('data-default') || label.textContent;
+    const col=state.columns[key];
+    const isAlias=col && col.aliasOf;
+    const allowMissing=key==='sku';
+    label.textContent = col?.name || fallback;
+    if(allowMissing && !col){
+      label.textContent = fallback || 'SKU';
+    }
+    const wrapper=label.closest('[data-col-wrapper]');
+    if(wrapper){
+      wrapper.hidden = (!col || isAlias) && !allowMissing;
+      const searchRoot=wrapper.querySelector('.dd-search-mode');
+      if(searchRoot){
+        const input=searchRoot.querySelector('.dd-search');
+        if(input){
+          const labelText=label.textContent.trim();
+          const dataPlaceholder=searchRoot.getAttribute('data-placeholder') || fallback || '';
+          const computedPlaceholder = computeSearchPlaceholder(labelText, dataPlaceholder);
+          input.placeholder = computedPlaceholder;
+          input.setAttribute('aria-label', computedPlaceholder);
+        }
+      }
+    }
+  });
+}
+
+function initFilters(options={}){
+  const token=++filterBackfillToken;
+  syncFilterLabels();
+  Object.values(el.dd).forEach(root=>root && ddBuild(root));
+  const requestedKeys=Array.isArray(options.initialKeys)?options.initialKeys.filter(key=>key && el.dd?.[key]):[];
+  const initialKeys=requestedKeys.length?Array.from(new Set(requestedKeys)):[];
+  if(initialKeys.length){
+    buildOptionsAll({keys:initialKeys, keepExisting:false});
+  }else{
+    buildOptionsAll();
+  }
+  el.filters.hidden=false;
+  const initialSet=new Set(initialKeys);
+  const remainingKeys=Object.keys(el.dd||{}).filter(key=>key && !initialSet.has(key));
+  return {token, remainingKeys};
+}
+function buildOptionsAll(options={}){
+  const keysOption=Array.isArray(options.keys)?options.keys.filter(Boolean):null;
+  const targetKeys=keysOption && keysOption.length ? Array.from(new Set(keysOption)) : Object.keys(el.dd||{});
+  if(!targetKeys.length) return;
+  buildOptionsForKeys(targetKeys, {keepExisting:options.keepExisting===true});
+  updateAllFilterOptions(null,{keys:targetKeys});
+}
+function buildOptionsForKeys(keys, options={}){
+  const keepSelections=options.keepExisting===true;
+  const keySet=new Set(keys);
+  for(const [k,root] of Object.entries(el.dd||{})){
+    if(!root) continue;
+    if(!keySet.has(k)) continue;
+    if(k==='sku') continue;
+    const col=state.columns[k];
+    if(!col || col.aliasOf) continue;
+    const values=uniqValues(k).map(v=>({v,count:0}));
+    ddSetOptions(root, values, keepSelections);
+  }
+}
+function scheduleDeferredFilterBuild(keys, token){
+  const queue=Array.isArray(keys)?Array.from(new Set(keys.filter(key=>key && el.dd?.[key]))):[];
+  if(!queue.length) return;
+  const runChunk=()=>{
+    if(token!==filterBackfillToken) return;
+    const chunk=queue.splice(0, FILTER_BACKFILL_CHUNK_SIZE);
+    if(!chunk.length) return;
+    buildOptionsAll({keys:chunk, keepExisting:true});
+    if(queue.length){
+      scheduleLowPriorityTask(runChunk);
+    }
+  };
+  scheduleLowPriorityTask(runChunk);
+}
+function scheduleLowPriorityTask(task){
+  if(typeof requestIdleCallback==='function'){
+    requestIdleCallback(()=>task());
+  }else{
+    setTimeout(task,60);
+  }
+}
+function uniqValues(kind){
+  const col=state.columns[kind]; if(!col || col.aliasOf) return [];
+  const info=getSqlInfoForStateKey(kind); if(!info) return [];
+  const table=state.sql?.table; if(!table) return [];
+  const rows=sqlQueryAll(`SELECT DISTINCT "${info.sqlName}" AS val FROM "${table}" WHERE "${info.sqlName}" IS NOT NULL AND "${info.sqlName}" <> ''`);
+  return rows.map(r=>String(r.val)).sort((a,b)=>String(a).localeCompare(String(b)));
+}
+function optionsWithCounts(kind, context){
+  const col=state.columns[kind]; if(!col || col.aliasOf) return [];
+  const info=getSqlInfoForStateKey(kind); if(!info) return [];
+  const table=state.sql?.table; if(!table) return [];
+  const extraCond={sql:`"${info.sqlName}" IS NOT NULL AND "${info.sqlName}" <> ''`};
+  const conds=context?.conditions || [];
+  const {sql,params}=combineWhere(conds, extraCond);
+  const rows=sqlQueryAll(`SELECT "${info.sqlName}" AS val, COUNT(*) AS cnt FROM "${table}" ${sql} GROUP BY "${info.sqlName}" ORDER BY cnt DESC, val COLLATE NOCASE`, params);
+  const map=new Map();
+  rows.forEach(row=>{ const value=row.val; if(value==null || value==='') return; map.set(String(value), Number(row.cnt)||0); });
+  const root=el.dd[kind]; const selected=new Set(ddGetSelected(root));
+  selected.forEach(v=>{ if(!map.has(v)) map.set(v,0); });
+  return [...map.entries()].sort((a,b)=> b[1]-a[1] || String(a[0]).localeCompare(String(b[0])) ).map(([v,count])=>({v,count}));
+}
+
+function skuOptionsWithCounts(context){
+  ensureAsinSkuMap();
+  const map=state.asinSkuMap;
+  if(!(map instanceof Map) || map.size===0) return [];
+  const asinInfo=getSqlInfoForStateKey('targetingAsin');
+  const table=state.sql?.table;
+  if(!asinInfo || !table) return [];
+  const extraCond={sql:`"${asinInfo.sqlName}" IS NOT NULL AND "${asinInfo.sqlName}" <> ''`};
+  const {sql,params}=combineWhere(context.conditions, extraCond);
+  const rows=sqlQueryAll(`SELECT "${asinInfo.sqlName}" AS asin, COUNT(*) AS cnt FROM "${table}" ${sql} GROUP BY "${asinInfo.sqlName}"`, params);
+  const counts=new Map();
+  const asinValueMap = state.asinValueMap instanceof Map ? state.asinValueMap : (state.asinValueMap=new Map());
+  asinValueMap.clear();
+  rows.forEach(row=>{
+    const asinValue=row.asin==null?'':String(row.asin).trim();
+    if(!asinValue) return;
+    const asinKey=normalizeAsinKey(asinValue);
+    if(asinKey) asinValueMap.set(asinKey, asinValue);
+    const count=Number(row.cnt)||0;
+    const entries=lookupAsinSkus(asinValue);
+    const values=skuEntriesToValues(entries);
+    if(!values.length) return;
+    const seenLocal=new Set();
+    values.forEach(val=>{
+      const norm=normalizeSkuKey(val);
+      if(!norm || seenLocal.has(norm)) return;
+      seenLocal.add(norm);
+      const existing=counts.get(norm);
+      if(existing){
+        existing.count+=count;
+        if(!existing.value) existing.value=val;
+      }else{
+        counts.set(norm,{value:val,count});
+      }
+    });
+  });
+  const root=el.dd?.sku;
+  if(root){
+    ddGetSelected(root).forEach(val=>{
+      const norm=normalizeSkuKey(val);
+      if(!norm) return;
+      if(!counts.has(norm)) counts.set(norm,{value:val,count:0});
+    });
+  }
+  return Array.from(counts.values()).sort((a,b)=> b.count-a.count || a.value.localeCompare(b.value));
+}
+
+function skuValuesToAsins(skuValues){
+  if(!Array.isArray(skuValues) || !skuValues.length) return [];
+  ensureAsinSkuMap();
+  const map=state.asinSkuMap;
+  if(!(map instanceof Map) || map.size===0) return [];
+  const targets=new Set();
+  skuValues.forEach(value=>{
+    const norm=normalizeSkuKey(value);
+    if(norm) targets.add(norm);
+  });
+  if(!targets.size) return [];
+  const asinValueMap = state.asinValueMap instanceof Map ? state.asinValueMap : (state.asinValueMap=new Map());
+  const asinSet=new Set();
+  map.forEach((entries, asinKey)=>{
+    if(!entries || !entries.length) return;
+    const values=skuEntriesToValues(entries);
+    for(const val of values){
+      const norm=normalizeSkuKey(val);
+      if(norm && targets.has(norm)){
+        asinSet.add(asinValueMap.get(asinKey) || asinKey);
+        break;
+      }
+    }
+  });
+  return Array.from(asinSet);
+}
+
+function setFilterSelections(root, values, caseInsensitive=false){
+  if(!root) return false;
+  const checkboxes=Array.from(root.querySelectorAll('.dd-list input[type=checkbox]'));
+  if(!checkboxes.length) return false;
+  const normalize=value=>caseInsensitive?String(value||'').toLocaleLowerCase():String(value||'');
+  const targetSet=new Set((Array.isArray(values)?values:[]).map(normalize));
+  const current=ddGetSelected(root).map(normalize);
+  const currentSet=new Set(current);
+  const changed = current.length!==targetSet.size || [...targetSet].some(val=>!currentSet.has(val));
+  checkboxes.forEach(cb=>{
+    const match=targetSet.has(normalize(cb.value));
+    cb.checked=match;
+  });
+  ddUpdateSummary(root);
+  ddSyncSelectAll(root);
+  ddRefreshSearchSelections(root);
+  return changed;
+}
+
+function applySkuFilterSelection(values, triggerRender=true){
+  const skuRoot=el.dd?.sku;
+  if(!skuRoot) return false;
+  const list=Array.isArray(values)?values.map(v=>String(v).trim()).filter(Boolean):[];
+  const targetSet=new Set(list.map(normalizeSkuKey));
+  const currentSet=new Set(ddGetSelected(skuRoot).map(normalizeSkuKey));
+  const sameSelection = targetSet.size>0 && targetSet.size===currentSet.size && [...targetSet].every(v=>currentSet.has(v));
+  const finalValues = sameSelection ? [] : list;
+  const changed=setFilterSelections(skuRoot, finalValues, false);
+  if(!changed && !sameSelection) return false;
+  onSkuFilterSelectionChange(triggerRender);
+  return true;
+}
+
+function onSkuFilterSelectionChange(triggerRender=true){
+  const skuRoot=el.dd?.sku;
+  if(!skuRoot) return;
+  const selected=ddGetSelected(skuRoot);
+  const asinRoot=el.dd?.targetingAsin;
+  let asinChanged=false;
+  const prevSync=skuSyncing;
+  skuSyncing=true;
+  try{
+    if(asinRoot){
+      const asinValues=skuValuesToAsins(selected);
+      asinChanged=setFilterSelections(asinRoot, asinValues, false);
+    }
+  }finally{
+    skuSyncing=prevSync;
+  }
+  if(!state.hasData) return;
+  if(triggerRender || asinChanged){
+    updateAllFilterOptions(skuRoot);
+    resetConversionPaging();
+    renderAll();
+    updateResetButtonVisibility();
+  }
+}
+
+function onAsinFilterSelectionChange(){
+  if(skuSyncing) return;
+  const asinRoot=el.dd?.targetingAsin;
+  if(!asinRoot) return;
+  const selected=ddGetSelected(asinRoot);
+  syncSkuFilterFromAsins(selected,{silent:true});
+}
+
+function syncSkuFilterFromAsins(asins,{silent=true}={}){
+  const skuRoot=el.dd?.sku;
+  if(!skuRoot) return false;
+  ensureAsinSkuMap();
+  const targetValues=new Set();
+  (Array.isArray(asins)?asins:[]).forEach(asin=>{
+    skuEntriesToValues(lookupAsinSkus(asin)).forEach(val=>{ if(val) targetValues.add(val); });
+  });
+  const prevSync=skuSyncing;
+  skuSyncing=true;
+  const changed=setFilterSelections(skuRoot, Array.from(targetValues), false);
+  skuSyncing=prevSync;
+  if(!silent && changed && state.hasData){
+    updateAllFilterOptions(skuRoot);
+    resetConversionPaging();
+    renderAll();
+    updateResetButtonVisibility();
+  }
+  return changed;
+}
+
+function activeSelections(excludeRoot){
+  const keyOf = n => state.columns[n] ? normalize(state.columns[n].name) : null;
+  const act={};
+  Object.entries(el.dd).forEach(([k,root])=>{
+    const col=state.columns[k];
+    if(!col || col.aliasOf) return;
+    if(excludeRoot && root===excludeRoot) return;
+    const vals=ddGetSelected(root); if(vals.length) act[keyOf(k)] = new Set(vals.map(String));
+  });
+  const dateKey=keyOf('date');
+  let from=null, to=null;
+  if(dateKey && state.customRange.active){
+    from=cloneDate(state.customRange.start); if(from) from.setHours(0,0,0,0);
+    to=cloneDate(state.customRange.end); if(to) to.setHours(23,59,59,999);
+  }
+  const monthSet=new Set(state.monthSel);
+  return {act,dateKey,from,to,monthSet};
+}
+function buildFilterContext(excludeRoot){
+  const selection=activeSelections(excludeRoot);
+  const {act,dateKey,from,to,monthSet}=selection;
+  const conditions=[];
+  const dateInfo=dateKey?getSqlColumn(dateKey):null;
+  if((from||to||monthSet.size) && !dateInfo){
+    conditions.push({sql:'0'});
+    return {conditions, meta:{dateInfo:null, from, to, monthSet}};
+  }
+  if(from && dateInfo){
+    conditions.push({sql:`"${dateInfo.sqlName}" >= ?`, params:[toInputDate(from)]});
+  }
+  if(to && dateInfo){
+    conditions.push({sql:`"${dateInfo.sqlName}" <= ?`, params:[toInputDate(to)]});
+  }
+  if(monthSet.size && dateInfo){
+    const months=Array.from(monthSet).sort();
+    const placeholders=months.map(()=>'?').join(',');
+    conditions.push({sql:`substr("${dateInfo.sqlName}",1,7) IN (${placeholders})`, params:months});
+  }
+  Object.entries(act).forEach(([colKey,set])=>{
+    if(!set || !set.size) return;
+    const info=getSqlColumn(colKey);
+    if(!info) return;
+    const values=Array.from(set);
+    const placeholders=values.map(()=>'?').join(',');
+    conditions.push({sql:`CAST("${info.sqlName}" AS TEXT) IN (${placeholders})`, params:values});
+  });
+  return {conditions, meta:{dateInfo, from, to, monthSet}};
+}
+function updateAllFilterOptions(excludeRoot, options={}){
+  const keysOption=Array.isArray(options.keys)?options.keys.filter(Boolean):null;
+  const targetKeys=keysOption && keysOption.length ? new Set(keysOption) : null;
+  const fullContext=buildFilterContext(null);
+  const excludedContext=excludeRoot ? buildFilterContext(excludeRoot) : fullContext;
+  Object.entries(el.dd).forEach(([k,root])=>{
+    if(!root) return;
+    if(targetKeys && !targetKeys.has(k)) return;
+    const contextForRoot = (excludeRoot && root===excludeRoot) ? excludedContext : fullContext;
+    if(k==='sku'){
+      ddSetOptions(root, skuOptionsWithCounts(contextForRoot), true);
+      return;
+    }
+    const col=state.columns[k];
+    if(!col || col.aliasOf) return;
+    ddSetOptions(root, optionsWithCounts(k, contextForRoot), true);
+  });
+}
+
+/* ===== KPIs ===== */
+function computeKPIs(context){
+  const table=state.sql?.table;
+  if(!table) return {I:0,C:0,R:0,S:0,ctr:NaN,acos:NaN,roas:NaN,avgcpc:NaN};
+  const imprInfo=getSqlInfoForStateKey('impressions');
+  const clicksInfo=getSqlInfoForStateKey('clicks');
+  const revenueInfo=getSqlInfoForStateKey('revenue');
+  const spendInfo=getSqlInfoForStateKey('spend');
+  const parts=[
+    imprInfo?`SUM(COALESCE("${imprInfo.sqlName}",0)) AS impressions`:'0 AS impressions',
+    clicksInfo?`SUM(COALESCE("${clicksInfo.sqlName}",0)) AS clicks`:'0 AS clicks',
+    revenueInfo?`SUM(COALESCE("${revenueInfo.sqlName}",0)) AS revenue`:'0 AS revenue',
+    spendInfo?`SUM(COALESCE("${spendInfo.sqlName}",0)) AS spend`:'0 AS spend'
+  ];
+  const {sql,params}=combineWhere(context.conditions);
+  const row=sqlQueryAll(`SELECT ${parts.join(', ')} FROM "${table}" ${sql}`, params)[0] || {};
+  const I=Number(row.impressions)||0;
+  const C=Number(row.clicks)||0;
+  const R=Number(row.revenue)||0;
+  const S=Number(row.spend)||0;
+  const ctr = I>0 ? C/I : NaN;
+  const acos = R>0 ? S/R : (S>0 ? Infinity : NaN);
+  const roas = S>0 ? R/S : NaN;
+  const avgcpc = C>0 ? S/C : NaN;
+  return {I,C,R,S,ctr,acos,roas,avgcpc};
+}
+function buildKpiSeries(context){
+  const series={spend:[], revenue:[], acos:[], clicks:[], impressions:[], ctr:[], roas:[], avgcpc:[]};
+  const table=state.sql?.table;
+  const dateInfo=getSqlInfoForStateKey('date');
+  if(!table || !dateInfo) return series;
+  const spendInfo=getSqlInfoForStateKey('spend');
+  const revenueInfo=getSqlInfoForStateKey('revenue');
+  const clicksInfo=getSqlInfoForStateKey('clicks');
+  const imprInfo=getSqlInfoForStateKey('impressions');
+  const hasSpend=!!spendInfo;
+  const hasRevenue=!!revenueInfo;
+  const hasClicks=!!clicksInfo;
+  const hasImpr=!!imprInfo;
+  const extra={sql:`"${dateInfo.sqlName}" IS NOT NULL AND "${dateInfo.sqlName}" <> ''`};
+  const {sql,params}=combineWhere(context.conditions, extra);
+  const selects=[`"${dateInfo.sqlName}" AS date_value`];
+  if(hasSpend) selects.push(`SUM(COALESCE("${spendInfo.sqlName}",0)) AS spend`);
+  if(hasRevenue) selects.push(`SUM(COALESCE("${revenueInfo.sqlName}",0)) AS revenue`);
+  if(hasClicks) selects.push(`SUM(COALESCE("${clicksInfo.sqlName}",0)) AS clicks`);
+  if(hasImpr) selects.push(`SUM(COALESCE("${imprInfo.sqlName}",0)) AS impressions`);
+  const query=`SELECT ${selects.join(', ')} FROM "${table}" ${sql} GROUP BY "${dateInfo.sqlName}" ORDER BY "${dateInfo.sqlName}"`;
+  const rows=sqlQueryAll(query, params);
+  rows.forEach(row=>{
+    const spend=hasSpend?Number(row.spend)||0:0;
+    const revenue=hasRevenue?Number(row.revenue)||0:0;
+    const clicks=hasClicks?Number(row.clicks)||0:0;
+    const impr=hasImpr?Number(row.impressions)||0:0;
+    if(hasSpend) series.spend.push(spend);
+    if(hasRevenue) series.revenue.push(revenue);
+    if(hasSpend && hasRevenue) series.acos.push(revenue>0?spend/revenue:(spend>0?Infinity:NaN));
+    if(hasClicks) series.clicks.push(clicks);
+    if(hasImpr) series.impressions.push(impr);
+    if(hasClicks && hasImpr) series.ctr.push(impr>0?clicks/impr:NaN);
+    if(hasSpend && hasRevenue) series.roas.push(spend>0?revenue/spend:NaN);
+    if(hasSpend && hasClicks) series.avgcpc.push(clicks>0?spend/clicks:NaN);
+  });
+  return series;
+}
+function renderKPIs(x, series){
+  el.kpi.spend.textContent   = fmt.money0(x.S);
+  el.kpi.revenue.textContent = fmt.money0(x.R);
+  el.kpi.acos.textContent    = isFinite(x.acos) ? (x.acos*100).toFixed(2)+'%' : '—';
+  el.kpi.clicks.textContent  = fmt.int(x.C);
+  el.kpi.impr.textContent    = fmt.int(x.I);
+  el.kpi.ctr.textContent     = isFinite(x.ctr) ? (x.ctr*100).toFixed(2)+'%' : '—';
+  el.kpi.roas.textContent    = isFinite(x.roas) ? x.roas.toFixed(2)+'x' : '—';
+  el.kpi.avgcpc.textContent  = isFinite(x.avgcpc) ? fmt.money(x.avgcpc) : '—';
+  lastKpiSeries = series || null;
+  updateKpiSparks(series);
+}
+function ensureKpiSparklines(){
+  if(!el.kpis) return;
+  const cards=el.kpis.querySelectorAll('.kpi[data-kpi]');
+  cards.forEach(card=>{
+    const key=card.getAttribute('data-kpi');
+    if(!key || kpiSparkCache.has(key)) return;
+    const canvas=document.createElement('canvas');
+    canvas.className='kpi-spark';
+    card.appendChild(canvas);
+    const ctx=canvas.getContext('2d');
+    kpiSparkCache.set(key,{card,canvas,ctx});
+  });
+}
+function drawKpiSpark(meta, values){
+  const {card,canvas,ctx}=meta||{};
+  if(!card || !canvas || !ctx){ return; }
+  const isSmall=card.classList.contains('small');
+  const widthRatio=isSmall?0.48:0.45;
+  const widthMax=isSmall?82:90;
+  const widthMin=isSmall?48:54;
+  const width=Math.max(widthMin, Math.min(widthMax, card.clientWidth*widthRatio));
+  const heightPaddingTop=10;
+  const heightPaddingBottom=8;
+  const height=Math.max(36, card.clientHeight-(heightPaddingTop+heightPaddingBottom));
+  const dpr=window.devicePixelRatio||1;
+  canvas.width=Math.round(width*dpr);
+  canvas.height=Math.round(height*dpr);
+  canvas.style.width=`${width}px`;
+  canvas.style.height=`${height}px`;
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+  ctx.clearRect(0,0,width,height);
+  const arr=Array.isArray(values)?values.filter(v=>Number.isFinite(v)):[];
+  if(arr.length===0){ return; }
+  let min=Math.min(...arr);
+  let max=Math.max(...arr);
+  if(!Number.isFinite(min) || !Number.isFinite(max)){ return; }
+  if(max===min){
+    const pad=Math.abs(max||1)*0.05 || 1;
+    min-=pad; max+=pad;
+  }else{
+    const pad=(max-min)*0.08;
+    min-=pad; max+=pad;
+  }
+  const points=[];
+  const step=arr.length>1 ? width/(arr.length-1) : width/2;
+  let idx=0;
+  values.forEach(val=>{
+    if(!Number.isFinite(val)) return;
+    const x=arr.length>1 ? idx*step : width/2;
+    const ratio=(val-min)/(max-min);
+    const y=height - Math.max(0, Math.min(1, ratio))*height;
+    points.push({x,y});
+    idx++;
+  });
+  const accent=getComputedStyle(document.body).getPropertyValue('--accent').trim() || '#2563eb';
+  ctx.lineWidth=2.4;
+  ctx.lineJoin='round';
+  ctx.lineCap='round';
+  ctx.strokeStyle=accent;
+  if(points.length<=1){
+    const y=points.length?points[0].y:height/2;
+    ctx.beginPath();
+    ctx.moveTo(0,y);
+    ctx.lineTo(width,y);
+    ctx.stroke();
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for(let i=1;i<points.length-1;i++){
+    const xc=(points[i].x+points[i+1].x)/2;
+    const yc=(points[i].y+points[i+1].y)/2;
+    ctx.quadraticCurveTo(points[i].x, points[i].y, xc, yc);
+  }
+  ctx.lineTo(points[points.length-1].x, points[points.length-1].y);
+  ctx.stroke();
+}
+function updateKpiSparks(series){
+  ensureKpiSparklines();
+  const metrics=['spend','revenue','acos','clicks','impressions','ctr','roas','avgcpc'];
+  metrics.forEach(key=>{
+    const meta=kpiSparkCache.get(key);
+    if(!meta) return;
+    const values=series && Array.isArray(series[key]) ? series[key] : [];
+    drawKpiSpark(meta, values);
+  });
+}
+
+function finalizeAgg(map, limit, options={}){
+  if(!(map instanceof Map) || map.size===0){
+    return {labels:[], spend:[], sales:[], acos:[], total:0, truncated:false, totalSpend:0, totalSales:0, limit:null, page:{start:0,count:0,size:0,current:0,totalPages:0,hasPrev:false,hasNext:false,total:0}};
+  }
+  const caseInsensitive=!!options.caseInsensitive;
+  const entries=[];
+  let totalSpend=0;
+  let totalSales=0;
+  map.forEach((value,labelKey)=>{
+    const spend=+value.spend||0;
+    const sales=+value.sales||0;
+    const acos=sales>0 ? spend/sales : (spend>0 ? Infinity : NaN);
+    const displayLabel = Object.prototype.hasOwnProperty.call(value,'displayLabel') ? value.displayLabel : labelKey;
+    const rawValue = Object.prototype.hasOwnProperty.call(value,'rawValue') ? value.rawValue : displayLabel;
+    const matchKey = Object.prototype.hasOwnProperty.call(value,'matchKey') ? value.matchKey : (caseInsensitive ? String(labelKey) : null);
+    entries.push({label:String(displayLabel), rawValue, spend, sales, acos, matchKey});
+    totalSpend+=spend;
+    totalSales+=sales;
+  });
+  const sortValue=v=>{
+    if(Number.isNaN(v)) return Number.NEGATIVE_INFINITY;
+    if(v===Infinity) return Number.POSITIVE_INFINITY;
+    if(v===-Infinity) return Number.NEGATIVE_INFINITY;
+    return v;
+  };
+  entries.sort((a,b)=>{
+    if(b.sales!==a.sales) return b.sales - a.sales;
+    const aAcos=sortValue(a.acos);
+    const bAcos=sortValue(b.acos);
+    if(bAcos>aAcos) return 1;
+    if(bAcos<aAcos) return -1;
+    return String(a.label).localeCompare(String(b.label));
+  });
+  const allRows=entries.map(entry=>({
+    label:entry.label,
+    rawValue:entry.rawValue,
+    spend:entry.spend,
+    sales:entry.sales,
+    acos:entry.acos,
+    matchKey:entry.matchKey
+  }));
+  const maxRows=(Number.isFinite(limit)&&limit>0)?Math.floor(limit):null;
+  let output=entries;
+  let pageMeta={start:0,count:entries.length,size:maxRows||entries.length,current:0,totalPages:maxRows?Math.ceil(entries.length/(maxRows||1)): (entries.length?1:0),hasPrev:false,hasNext:false,total:entries.length};
+  if(maxRows){
+    const totalPages=entries.length ? Math.ceil(entries.length/maxRows) : 0;
+    let pageIndex=Number.isFinite(options.page)?Math.max(0, Math.floor(options.page)):0;
+    if(totalPages>0){
+      pageIndex=Math.min(pageIndex, totalPages-1);
+    }else{
+      pageIndex=0;
+    }
+    const start=pageIndex*maxRows;
+    const end=start+maxRows;
+    output=entries.slice(start,end);
+    const count=output.length;
+    pageMeta={
+      start,
+      count,
+      size:maxRows,
+      current:pageIndex,
+      totalPages,
+      hasPrev:start>0,
+      hasNext:end<entries.length,
+      total:entries.length
+    };
+  }
+  const truncated=!!(maxRows && entries.length>output.length);
+  return {
+    labels:output.map(e=>e.label),
+    rawValues:output.map(e=>e.rawValue),
+    matchKeys:output.map(e=>e.matchKey??null),
+    spend:output.map(e=>e.spend),
+    sales:output.map(e=>e.sales),
+    acos:output.map(e=>e.acos),
+    total:entries.length,
+    truncated,
+    totalSpend,
+    totalSales,
+    limit:maxRows,
+    page:pageMeta,
+    allRows
+  };
+}
+
+function buildAggSql(context, columnKey, spendInfo, salesInfo, options={}){
+  const table=state.sql?.table;
+  if(!table) return {labels:[], spend:[], sales:[], acos:[]};
+  const columnInfo=getSqlColumn(columnKey);
+  if(!columnInfo || !spendInfo || !salesInfo) return {labels:[], spend:[], sales:[], acos:[]};
+  const caseInsensitive=!!options.caseInsensitive;
+  const labelExpr=`"${columnInfo.sqlName}"`;
+  const groupExpr=caseInsensitive?`LOWER(${labelExpr})`:labelExpr;
+  const displayExpr=caseInsensitive?`MAX(${labelExpr})`:labelExpr;
+  const extraCond={sql:`TRIM(${labelExpr}) <> ''`};
+  const extras=[extraCond];
+  const baseFilters=[];
+  if(options.baseFilter) baseFilters.push(options.baseFilter);
+  if(Array.isArray(options.baseFilters)) baseFilters.push(...options.baseFilters);
+  baseFilters.forEach(filter=>{
+    if(!filter) return;
+    if(filter.sql){
+      const params=Array.isArray(filter.params)?filter.params:[];
+      extras.push({sql:String(filter.sql), params});
+      return;
+    }
+    const values=Array.isArray(filter.values)?filter.values.filter(v=>String(v??'').trim()!=='')
+      : (filter.value!=null?[filter.value]:[]);
+    if(!values.length) return;
+    const stateKey=filter.stateKey || filter.columnKey || '';
+    const columnKey=filter.columnKey ? normalize(filter.columnKey) : '';
+    let info=null;
+    if(columnKey) info=getSqlColumn(columnKey);
+    if(!info && stateKey) info=getSqlInfoForStateKey(stateKey);
+    const cond=buildSqlInCondition(info, values);
+    if(cond) extras.push(cond);
+  });
+  const pivotFilter=options?.pivotFilter;
+  if(pivotFilter) appendDateFilterExtras(extras, pivotFilter);
+  const {sql,params}=combineWhere(context.conditions, extras);
+  const query=`SELECT ${groupExpr} AS group_key, ${displayExpr} AS display_label, SUM(COALESCE("${spendInfo.sqlName}",0)) AS total_spend, SUM(COALESCE("${salesInfo.sqlName}",0)) AS total_sales FROM "${table}" ${sql} GROUP BY ${groupExpr} HAVING total_spend <> 0 OR total_sales <> 0`;
+  const rows=sqlQueryAll(query, params);
+  const map=new Map();
+  rows.forEach(row=>{
+    const display=row.display_label==null?'':String(row.display_label);
+    const trimmed=display.trim();
+    if(!trimmed) return;
+    const spend=Number(row.total_spend)||0;
+    const sales=Number(row.total_sales)||0;
+    if(caseInsensitive){
+      const key=String(row.group_key||'');
+      const entry=map.get(key);
+      if(entry){
+        entry.spend+=spend;
+        entry.sales+=sales;
+        if(!entry.displayLabel && display) entry.displayLabel=display;
+      }else{
+        map.set(key,{spend,sales,rawValue:display,displayLabel:display,matchKey:key});
+      }
+    }else{
+      map.set(display,{spend,sales,rawValue:display,displayLabel:display});
+    }
+  });
+  return finalizeAgg(map, undefined, {caseInsensitive});
+}
+
+function updatePivotFootSpace(table){
+  if(!table) return;
+  const body = table.closest('.pivot-body');
+  if(!body) return;
+  const apply=()=>{
+    const foot=table.querySelector('tfoot');
+    if(!foot){
+      body.style.setProperty('--pivot-foot-space','0px');
+      schedulePivotLayout();
+      return;
+    }
+    const rect=foot.getBoundingClientRect();
+    const height=Math.ceil(rect.height||0);
+    const gap=Math.max(0, height+12);
+    body.style.setProperty('--pivot-foot-space', `${gap}px`);
+    schedulePivotLayout();
+  };
+  if(typeof requestAnimationFrame==='function') requestAnimationFrame(apply);
+  else apply();
+}
+
+function schedulePivotLayout(){
+  if(typeof requestAnimationFrame!=='function'){
+    updatePivotLayout();
+    return;
+  }
+  if(pivotLayoutFrame) cancelAnimationFrame(pivotLayoutFrame);
+  pivotLayoutFrame=requestAnimationFrame(()=>{
+    pivotLayoutFrame=null;
+    updatePivotLayout();
+  });
+}
+
+function updatePivotLayout(){
+  const section=el.pivot?.section;
+  if(!section || section.hidden){
+    return;
+  }
+  const cards=Array.from(section.querySelectorAll('.pivot-card'));
+  if(!cards.length){
+    section.style.removeProperty('--pivot-auto-rows');
+    return;
+  }
+  const styles=getComputedStyle(section);
+  let rowHeight=parseFloat(styles.getPropertyValue('--pivot-auto-rows'));
+  if(!Number.isFinite(rowHeight) || rowHeight<=0){
+    rowHeight=12;
+    section.style.setProperty('--pivot-auto-rows', `${rowHeight}px`);
+  }
+  const rowGap=parseFloat(styles.rowGap)||0;
+  const denom=rowHeight+rowGap;
+  cards.forEach(card=>{
+    if(card.hidden){
+      card.style.removeProperty('grid-row-end');
+      return;
+    }
+    const rect=card.getBoundingClientRect();
+    const height=rect.height;
+    if(!height){
+      card.style.removeProperty('grid-row-end');
+      return;
+    }
+    const span=Math.max(1, Math.ceil((height+rowGap)/(denom||1)));
+    card.style.gridRowEnd=`span ${span}`;
+  });
+}
+
+function renderPivotTable(table){
+  if(!table) return;
+  const data=table._pivotData;
+  if(!data){
+    table.innerHTML='';
+    table.classList.remove('has-grand-total');
+    updatePivotFootSpace(table);
+    schedulePivotLayout();
+    return;
+  }
+
+  const safeColumn=escapeHtml(data.displayName||'Group');
+  const sort=table._pivotSort || (table._pivotSort={key:null,dir:'desc'});
+  if(sort.key && !PIVOT_SORT_KEYS.has(sort.key)){
+    sort.key=null;
+  }
+  if(sort.dir!=='asc' && sort.dir!=='desc'){
+    sort.dir='desc';
+  }
+
+  const baseRows = Array.isArray(data.allRows) && data.allRows.length
+    ? data.allRows.slice()
+    : Array.isArray(data.rows)?data.rows.slice():[];
+  const dimension=data.dimension||null;
+  if(sort.key){
+    baseRows.sort((a,b)=>comparePivotRows(a,b,sort.key,sort.dir));
+  }
+
+  const showSkuColumn=!!data.showSkuColumn;
+  const showBrandColumn=!!data.showBrandColumn;
+  const head=buildPivotHead(safeColumn, sort.key, sort.dir, showSkuColumn, showBrandColumn);
+  const columnCount=5 + (showSkuColumn?1:0) + (showBrandColumn?1:0);
+
+  if(!baseRows.length){
+    const colspan=columnCount;
+    table.innerHTML = head + `<tbody><tr><td colspan="${colspan}" class="pivot-empty">No ${safeColumn} data for current filters.</td></tr></tbody>`;
+    table.classList.remove('has-grand-total');
+    updatePivotFootSpace(table);
+    schedulePivotLayout();
+    data.visibleRows=[];
+    return;
+  }
+
+  const page=data.page||null;
+  const pageStart=page && Number.isFinite(page.start) ? Math.max(0, page.start) : 0;
+  const pageCount=page && Number.isFinite(page.count) ? Math.max(0, page.count)
+    : page && Number.isFinite(page.size) ? Math.max(0, page.size)
+    : baseRows.length;
+  const visibleRows=baseRows.slice(pageStart, Math.min(baseRows.length, pageStart+pageCount));
+
+  if(!visibleRows.length){
+    const colspan=columnCount;
+    table.innerHTML = head + `<tbody><tr><td colspan="${colspan}" class="pivot-empty">No ${safeColumn} rows on this page.</td></tr></tbody>`;
+    table.classList.remove('has-grand-total');
+    updatePivotFootSpace(table);
+    schedulePivotLayout();
+    data.visibleRows=[];
+    return;
+  }
+
+  data.visibleRows=visibleRows;
+
+  const barScale=Number.isFinite(data.barScale) && data.barScale>0 ? data.barScale : 100;
+  const bodyRows=visibleRows.map(row=>{
+    const labelCell=buildPivotLabelCell(row, dimension, data);
+    const skuCell=showSkuColumn?buildPivotSkuCell(row):'';
+    const brandCell=showBrandColumn?buildPivotBrandCell(row):'';
+    const spendCell=buildPivotMoneyCell(row.spend);
+    const salesCell=buildPivotMoneyCell(row.sales);
+    const acosCells=buildPivotAcosCells(row.acos, barScale, false);
+    return `<tr>${labelCell}${skuCell}${brandCell}${spendCell}${salesCell}${acosCells}</tr>`;
+  }).join('');
+
+  const totalSpend=Number(data.totals?.spend)||0;
+  const totalSales=Number(data.totals?.sales)||0;
+  const totalAcos=typeof data.totals?.acos==='number'?data.totals.acos:NaN;
+  const totalSkuCell=showSkuColumn?'<td class="pivot-sku"></td>':'';
+  const totalBrandCell=showBrandColumn?'<td class="pivot-brand"></td>':'';
+  const totalRow=`<tr class="pivot-total"><th scope="row">Grand Total</th>${totalSkuCell}${totalBrandCell}${buildPivotMoneyCell(totalSpend)}${buildPivotMoneyCell(totalSales)}${buildPivotAcosCells(totalAcos, barScale, true)}</tr>`;
+
+  table.innerHTML = head + `<tbody>${bodyRows}</tbody><tfoot>${totalRow}</tfoot>`;
+  table.classList.add('has-grand-total');
+  updatePivotFootSpace(table);
+  schedulePivotLayout();
+}
+
+function buildPivotHead(columnLabel, activeKey, activeDir, showSkuColumn, showBrandColumn){
+  const cells=[
+    buildPivotHeadCell('label', columnLabel, '', activeKey, activeDir)
+  ];
+  if(showSkuColumn){
+    cells.push(buildPivotHeadCell('sku', 'SKU', 'pivot-sku', activeKey, activeDir));
+  }
+  if(showBrandColumn){
+    cells.push(buildPivotHeadCell('brand', 'Brand', 'pivot-brand', activeKey, activeDir));
+  }
+  cells.push(
+    buildPivotHeadCell('spend', 'Spend', '', activeKey, activeDir),
+    buildPivotHeadCell('sales', 'Sales', '', activeKey, activeDir),
+    buildPivotHeadCell('acos', 'ACOS', 'pivot-acos', activeKey, activeDir),
+    '<th scope="col" class="pivot-acos-bar" aria-hidden="true"></th>'
+  );
+  return `<thead><tr>${cells.join('')}</tr></thead>`;
+}
+
+function buildPivotLabelCell(row, dimension, meta){
+  const label=String(row?.label ?? '');
+  const safeLabel=escapeHtml(label);
+  const rawValue = Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : label;
+  const matchKey = typeof row?.matchKey==='string' ? row.matchKey : null;
+  const hasDimension = dimension && dimension.stateKey && dimension.columnKey;
+  const rawString = rawValue==null ? '' : String(rawValue);
+  const trimmedRaw = rawString.trim();
+  const isFilterable = hasDimension && (dimension.stateKey==='term' ? trimmedRaw.length>0 : !(rawValue==null || rawString===''));
+  if(!isFilterable){
+    const content=`<span class="pivot-label-text">${safeLabel}</span>`;
+    return `<th scope="row">${content}</th>`;
+  }
+
+  const valueAttr=escapeHtml(rawString);
+  const matchAttr = matchKey ? ` data-pivot-match="${escapeHtml(String(matchKey))}"` : '';
+  const button=`<button type="button" class="pivot-label-btn" data-pivot-value="${valueAttr}"${matchAttr}><span class="pivot-label-text">${safeLabel}</span></button>`;
+  return `<th scope="row">${button}</th>`;
+}
+
+function buildPivotHeadCell(key, title, extraClass, activeKey, activeDir){
+  const sortable=PIVOT_SORT_KEYS.has(key);
+  const classes=['pivot-sortable'];
+  if(extraClass) classes.push(extraClass);
+  const classAttr=sortable?` class="${classes.join(' ')}"`:(extraClass?` class="${extraClass}"`:'');
+  const attrs=[`scope="col"`];
+  if(sortable){
+    attrs.push(`data-sort-key="${key}"`);
+    attrs.push('role="button"');
+    attrs.push('tabindex="0"');
+  }
+  if(sortable && activeKey===key){
+    attrs.push(`aria-sort="${activeDir==='asc'?'ascending':'descending'}"`);
+  }
+  const indicator=(sortable && activeKey===key)?`<span class="pivot-sort-indicator" aria-hidden="true">${activeDir==='asc'?'▲':'▼'}</span>`:'';
+  const safeTitle=escapeHtml(title);
+  return `<th ${attrs.join(' ')}${classAttr}><span class="pivot-sort-label">${safeTitle}${indicator}</span></th>`;
+}
+
+function buildPivotMoneyCell(value){
+  return `<td class="pivot-num">${escapeHtml(fmt.money0(value))}</td>`;
+}
+
+function buildPivotSkuCell(row){
+  let text='';
+  let values=[];
+  let asinRaw=null;
+  if(row && typeof row==='object'){
+    asinRaw=Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : row?.label;
+    if(Object.prototype.hasOwnProperty.call(row,'skuText')){
+      const stored=row.skuText;
+      text=stored==null?'':String(stored).trim();
+    }
+    if(Array.isArray(row?.skuList)){
+      values=row.skuList.filter(v=>v!=null && v!=='').map(v=>String(v));
+    }
+    if(!text){
+      const entries=lookupAsinSkus(asinRaw);
+      text=formatSkuEntries(entries);
+      row.skuText=text;
+      if(!values.length){
+        values=skuEntriesToValues(entries);
+        row.skuList=values.slice();
+      }
+    }
+  }
+  text=text.trim();
+  if(text){
+    return `<td class="pivot-sku"><span class="pivot-label-text">${escapeHtml(text)}</span></td>`;
+  }
+  return '<td class="pivot-sku">—</td>';
+}
+
+function buildPivotBrandCell(row){
+  let text='';
+  if(row && typeof row==='object'){
+    if(Object.prototype.hasOwnProperty.call(row,'brandText')){
+      const stored=row.brandText;
+      text=stored==null?'':String(stored).trim();
+    }
+    if(!text){
+      const rawValue=Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : row?.label;
+      const lookup=lookupAsinBrand(rawValue);
+      text=lookup?String(lookup).trim():'';
+      row.brandText=text;
+    }
+  }
+  if(text){
+    return `<td class="pivot-brand"><span class="pivot-label-text">${escapeHtml(text)}</span></td>`;
+  }
+  return '<td class="pivot-brand">—</td>';
+}
+
+function buildPivotAcosCells(value, barScale, isTotal){
+  if(!Number.isFinite(value)){
+    return '<td class="pivot-acos pivot-acos-empty">—</td><td class="pivot-acos-bar pivot-acos-empty"></td>';
+  }
+  const pct=value*100;
+  const width=Math.max(0, Math.min(100, barScale ? (pct/barScale)*100 : 0));
+  const cls=`pivot-amount${isTotal?' pivot-amount-total':''}`;
+  const valueCell=`<td class="pivot-acos"><span class="${cls}">${pct.toFixed(1)}%</span></td>`;
+  const barCell=`<td class="pivot-acos-bar"><div class="pivot-bar"><div class="pivot-bar-fill acos" style="width:${width}%"></div></div></td>`;
+  return valueCell+barCell;
+}
+
+function comparePivotRows(a,b,key,dir){
+  const aHasAcos=Number.isFinite(a?.acos);
+  const bHasAcos=Number.isFinite(b?.acos);
+  if(aHasAcos!==bHasAcos){
+    return aHasAcos ? -1 : 1;
+  }
+  if(key==='label'){
+    const cmp=PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+    return dir==='desc' ? -cmp : cmp;
+  }
+  if(key==='sku'){
+    const aVal=String(a?.skuSortKey ?? a?.skuText ?? '').trim();
+    const bVal=String(b?.skuSortKey ?? b?.skuText ?? '').trim();
+    const aEmpty=!aVal;
+    const bEmpty=!bVal;
+    if(aEmpty!==bEmpty){
+      return aEmpty ? 1 : -1;
+    }
+    const cmp=PIVOT_LABEL_COLLATOR.compare(aVal, bVal);
+    if(cmp!==0) return dir==='desc' ? -cmp : cmp;
+    return PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+  }
+  if(key==='brand'){
+    const aVal=String(a?.brandSortKey ?? a?.brandText ?? '').trim();
+    const bVal=String(b?.brandSortKey ?? b?.brandText ?? '').trim();
+    const aEmpty=!aVal;
+    const bEmpty=!bVal;
+    if(aEmpty!==bEmpty){
+      return aEmpty ? 1 : -1;
+    }
+    const cmp=PIVOT_LABEL_COLLATOR.compare(aVal, bVal);
+    if(cmp!==0) return dir==='desc' ? -cmp : cmp;
+    return PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+  }
+  const av=pivotSortInfo(a[key]);
+  const bv=pivotSortInfo(b[key]);
+
+  if(key==='acos'){
+    if(av.isNumber && !bv.isNumber) return -1;
+    if(!av.isNumber && bv.isNumber) return 1;
+  }else{
+    if(av.isNumber && !bv.isNumber) return -1;
+    if(!av.isNumber && bv.isNumber) return 1;
+  }
+
+  if(av.isNumber && bv.isNumber){
+    if(av.value===bv.value){
+      return PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+    }
+    if(!Number.isFinite(av.value) || !Number.isFinite(bv.value)){
+      if(dir==='desc'){
+        if(av.value===Infinity && bv.value!==Infinity) return -1;
+        if(av.value!==Infinity && bv.value===Infinity) return 1;
+        if(av.value===-Infinity && bv.value!==-Infinity) return 1;
+        if(av.value!==-Infinity && bv.value===-Infinity) return -1;
+      }else{
+        if(av.value===Infinity && bv.value!==Infinity) return 1;
+        if(av.value!==Infinity && bv.value===Infinity) return -1;
+        if(av.value===-Infinity && bv.value!==-Infinity) return -1;
+        if(av.value!==-Infinity && bv.value===-Infinity) return 1;
+      }
+    }
+    const diff = dir==='desc' ? (bv.value - av.value) : (av.value - bv.value);
+    if(diff!==0) return diff;
+    return PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+  }
+
+  return PIVOT_LABEL_COLLATOR.compare(String(a.label??''), String(b.label??''));
+}
+
+function pivotSortInfo(value){
+  const isNumber=typeof value==='number' && !Number.isNaN(value);
+  return {isNumber,value:isNumber?value:0};
+}
+
+function setPivotNote(card, text){
+  if(!card) return;
+  const message=(text==null?'':String(text)).trim();
+  let note=card.querySelector('.pivot-note');
+  if(!message){
+    if(note) note.remove();
+    return;
+  }
+  if(!note){
+    note=document.createElement('div');
+    note.className='pivot-note';
+    const body=card.querySelector('.pivot-body');
+    if(body && body.parentNode===card){
+      card.insertBefore(note, body);
+    }else{
+      card.appendChild(note);
+    }
+  }
+  note.textContent=message;
+}
+
+function renderPivotCard(target, columnLabel, agg, hasColumn){
+  if(!target || !target.card || !target.table) return false;
+  if(!hasColumn){
+    const slot=target.table?._pivotSlot || target.card?.dataset.pivotSlot || '';
+    if(slot) clearPivotFilterState(slot);
+    target.card.hidden = true;
+    if(target.card.style) target.card.style.removeProperty('grid-row-end');
+    target.table.innerHTML='';
+    target.table._pivotData=null;
+    target.table.classList.remove('has-grand-total');
+    updatePivotFootSpace(target.table);
+    schedulePivotLayout();
+    setPivotNote(target.card, '');
+    return false;
+  }
+
+  const displayName = columnLabel || 'Group';
+  target.card.hidden = false;
+  const titleTextNode = target.card.querySelector('.chart-title-text');
+  if(titleTextNode) titleTextNode.textContent = `${displayName} Performance Pivot`;
+  else{
+    const fallbackTitle=target.card.querySelector('.chart-title');
+    if(fallbackTitle) fallbackTitle.textContent = `${displayName} Performance Pivot`;
+
+  }
+
+  const labels = Array.isArray(agg?.labels) ? agg.labels : [];
+  const spendVals = Array.isArray(agg?.spend) ? agg.spend.map(v=>+v||0) : labels.map(()=>0);
+  const salesVals = Array.isArray(agg?.sales) ? agg.sales.map(v=>+v||0) : labels.map(()=>0);
+
+  if(!labels.length){
+    target.card.hidden = true;
+    if(target.card?.style) target.card.style.removeProperty('grid-row-end');
+    if(target.table){
+      target.table.innerHTML='';
+      target.table._pivotData=null;
+      target.table.classList.remove('has-grand-total');
+      updatePivotFootSpace(target.table);
+    }
+    setPivotNote(target.card, '');
+    schedulePivotLayout();
+    return false;
+  }
+
+  const parseAcosValue=(value)=>{
+    if(typeof value==='number') return value;
+    const str=String(value??'').trim();
+    if(!str) return NaN;
+    const cleaned=str.replace(/acos/ig,'').trim();
+    if(!/[0-9]/.test(cleaned)) return NaN;
+    const num=parseNumber(cleaned);
+    return Number.isFinite(num)?num:NaN;
+  };
+
+  const acosVals = (Array.isArray(agg?.acos) && agg.acos.length===labels.length)
+    ? agg.acos.map(parseAcosValue)
+    : labels.map((_,i)=>{
+        const sales=salesVals[i];
+        const spend=spendVals[i];
+        return sales>0 ? spend/sales : (spend>0 ? Infinity : NaN);
+      });
+
+  const totalSpend = Number.isFinite(agg?.totalSpend) ? agg.totalSpend : spendVals.reduce((sum,val)=>sum+val,0);
+  const totalSales = Number.isFinite(agg?.totalSales) ? agg.totalSales : salesVals.reduce((sum,val)=>sum+val,0);
+  const totalAcos = totalSales>0 ? totalSpend/totalSales : NaN;
+
+  const totalCount=Number.isFinite(agg?.total)?agg.total:labels.length;
+  const limit=Number.isFinite(agg?.limit)?agg.limit:null;
+  let truncatedNote='';
+  if(labels.length && limit && totalCount>labels.length && agg?.page){
+    const start=Number.isFinite(agg.page.start)?agg.page.start:0;
+    const from=Math.min(totalCount,start+1);
+    const to=Math.min(totalCount,start+labels.length);
+    truncatedNote=`Showing rows ${from.toLocaleString()}–${to.toLocaleString()} of ${totalCount.toLocaleString()} ${displayName} results. Totals include all filtered rows.`;
+  }else if(agg?.truncated){
+    const totalStr=totalCount.toLocaleString();
+    const limitStr=(limit||labels.length).toLocaleString();
+    truncatedNote=`Showing top ${limitStr} of ${totalStr} ${displayName} results. Totals include all filtered rows.`;
+  }
+  if(truncatedNote){
+    setPivotNote(target.card, truncatedNote);
+  }else{
+    setPivotNote(target.card, '');
+  }
+
+  const finiteAcos = acosVals.filter(Number.isFinite);
+  if(isFinite(totalAcos)) finiteAcos.push(totalAcos);
+  const maxPct = finiteAcos.length ? Math.max(...finiteAcos)*100 : 0;
+  const barMaxPct = Math.min(100, maxPct + 10);
+  const barScale = barMaxPct > 0 ? barMaxPct : 100;
+
+  const rawVals = Array.isArray(agg?.rawValues) ? agg.rawValues : labels.map(()=>null);
+  const matchKeys = Array.isArray(agg?.matchKeys) ? agg.matchKeys : labels.map(()=>null);
+  const rowData = labels.map((label,i)=>({
+    label:String(label),
+    rawValue:rawVals[i],
+    spend:spendVals[i],
+    sales:salesVals[i],
+    acos:acosVals[i],
+    matchKey:matchKeys[i]
+  }));
+
+  const allRows = Array.isArray(agg?.allRows)
+    ? agg.allRows.map(row=>({
+        label:String(row?.label??''),
+        rawValue:Object.prototype.hasOwnProperty.call(row||{},'rawValue')?row.rawValue:row?.label??'',
+        spend:+row?.spend||0,
+        sales:+row?.sales||0,
+        acos:typeof row?.acos==='number'?row.acos:parseAcosValue(row?.acos),
+        matchKey:row?.matchKey??null
+      }))
+    : rowData.map(r=>({...r}));
+
+  const slot=target.table?._pivotSlot || target.card?.dataset.pivotSlot || '';
+  const showSkuColumn=slot==='targetingAsin';
+  const showBrandColumn=slot==='conversionAsin' || slot==='targetingAsin';
+  if((showSkuColumn || showBrandColumn) && !state.asinSkuLoaded){
+    ensureAsinSkuMap();
+  }
+  let asinValueMap=null;
+  if(showSkuColumn || showBrandColumn){
+    asinValueMap = state.asinValueMap instanceof Map ? state.asinValueMap : (state.asinValueMap=new Map());
+    asinValueMap.clear();
+  }
+  if(showSkuColumn){
+    const annotateSku=row=>{
+      if(!row || typeof row!=='object') return;
+      const rawValue=Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : row?.label;
+      const asinValue=rawValue==null?'':String(rawValue);
+      const asinKey=normalizeAsinKey(asinValue);
+      if(asinKey && asinValueMap) asinValueMap.set(asinKey, asinValue);
+      let text=typeof row.skuText==='string'?row.skuText.trim():'';
+      let list=Array.isArray(row.skuList)?row.skuList.filter(v=>v!=null && v!=='').map(v=>String(v)) : [];
+      if(!text || !list.length){
+        const entries=lookupAsinSkus(rawValue);
+        if(!text) text=formatSkuEntries(entries);
+        if(!list.length) list=skuEntriesToValues(entries);
+        row.skuText=text;
+        row.skuList=list.slice();
+      }
+      const sortValue=list.length?list[0]:(text||'');
+      row.skuSortKey=sortValue;
+    };
+    rowData.forEach(annotateSku);
+    if(Array.isArray(allRows)){
+      allRows.forEach(annotateSku);
+    }
+  }
+  if(showBrandColumn){
+    const annotateBrand=row=>{
+      if(!row || typeof row!=='object') return;
+      const rawValue=Object.prototype.hasOwnProperty.call(row,'rawValue') ? row.rawValue : row?.label;
+      const asinValue=rawValue==null?'':String(rawValue);
+      const asinKey=normalizeAsinKey(asinValue);
+      if(asinKey && asinValueMap && !asinValueMap.has(asinKey)){
+        asinValueMap.set(asinKey, asinValue);
+      }
+      let text=typeof row.brandText==='string'?row.brandText.trim():'';
+      if(!text){
+        const lookup=lookupAsinBrand(rawValue);
+        text=lookup?String(lookup).trim():'';
+        row.brandText=text;
+      }else{
+        row.brandText=text;
+      }
+      row.brandSortKey=text?text.toLowerCase():'';
+    };
+    rowData.forEach(annotateBrand);
+    if(Array.isArray(allRows)){
+      allRows.forEach(annotateBrand);
+    }
+  }
+  if(slot) prunePivotFilter(slot, target.dimension, allRows);
+
+  const pageMeta = agg?.page
+    ? {...agg.page}
+    : {start:0,count:rowData.length,size:rowData.length,current:0,totalPages:rowData.length?1:0,hasPrev:false,hasNext:false,total:rowData.length};
+
+  target.table._pivotData={
+    displayName,
+    rows:allRows,
+    allRows,
+    visibleRows:rowData,
+    totals:{spend:totalSpend,sales:totalSales,acos:totalAcos},
+    barScale,
+    dimension: target.dimension || null,
+    slot: target.table ? (target.table._pivotSlot || null) : null,
+    page:pageMeta,
+    limit,
+    totalCount,
+    showSkuColumn,
+    showBrandColumn
+  };
+
+  if(!target.table._pivotSort){
+    target.table._pivotSort={key:null,dir:'desc'};
+  }
+
+  renderPivotTable(target.table);
+  return true;
+}
+
+function renderConversionPivots(context, spendInfo, salesInfo){
+  const result={st:false,asin:false};
+  const targetSt=el.pivot?.conversionSt;
+  const targetAsin=el.pivot?.conversionAsin;
+  const termCol=state.columns.term;
+  const typeCol=state.columns.customerType;
+  const baseLabel = termCol?.name || 'Customer Search Term';
+  const hasBasics = !!(spendInfo && salesInfo && termCol && typeCol);
+
+  if(targetSt?.table) targetSt.table._pivotSlot='conversionSt';
+  if(targetAsin?.table) targetAsin.table._pivotSlot='conversionAsin';
+
+  if(targetSt) targetSt.dimension = hasBasics ? {stateKey:'term', columnKey:normalize(termCol.name)} : null;
+  if(targetAsin) targetAsin.dimension = hasBasics ? {stateKey:'term', columnKey:normalize(termCol.name)} : null;
+
+  if(!hasBasics){
+    if(targetSt) renderPivotCard(targetSt, `${baseLabel} (ST)`, null, false);
+    if(targetAsin) renderPivotCard(targetAsin, `${baseLabel} (ASIN)`, null, false);
+    return result;
+  }
+
+  const table=state.sql?.table;
+  const termInfo=getSqlInfoForStateKey('term');
+  const typeInfo=getSqlInfoForStateKey('customerType');
+  if(!table || !termInfo || !typeInfo){
+    if(targetSt) renderPivotCard(targetSt, `${baseLabel} (ST)`, null, false);
+    if(targetAsin) renderPivotCard(targetAsin, `${baseLabel} (ASIN)`, null, false);
+    return result;
+  }
+
+  const normalizeTypeRaw=value=>String(value??'').trim().toLowerCase();
+  const typeCache=new Map();
+  const mapTypeValue=value=>{
+    const raw=normalizeTypeRaw(value);
+    if(typeCache.has(raw)) return typeCache.get(raw);
+    let mapped;
+    if(raw==='search term' || raw==='searchterm' || raw==='search-term' || raw==='st') mapped='st';
+    else if(raw==='asin' || raw==='product asin' || raw==='product-asin') mapped='asin';
+    else mapped=raw;
+    typeCache.set(raw,mapped);
+    return mapped;
+  };
+
+  const baseExtras=[
+    {sql:`TRIM("${termInfo.sqlName}") <> ''`},
+    {sql:`TRIM("${typeInfo.sqlName}") <> ''`}
+  ];
+
+  const runConversionQuery=(filter)=>{
+    const extras=baseExtras.map(item=>({...item}));
+    appendDateFilterExtras(extras, filter);
+    const {sql,params}=combineWhere(context.conditions, extras);
+    const query=`SELECT LOWER(TRIM("${typeInfo.sqlName}")) AS type_key, "${termInfo.sqlName}" AS term_value, SUM(COALESCE("${spendInfo.sqlName}",0)) AS total_spend, SUM(COALESCE("${salesInfo.sqlName}",0)) AS total_sales FROM "${table}" ${sql} GROUP BY type_key, term_value HAVING total_spend <> 0 OR total_sales <> 0`;
+    return sqlQueryAll(query, params);
+  };
+
+  const buildBucket=(rows, targetType)=>{
+    const bucket=new Map();
+    (Array.isArray(rows)?rows:[]).forEach(row=>{
+      const mappedType=mapTypeValue(row.type_key);
+      if(mappedType!==targetType) return;
+      const rawValue=row.term_value;
+      const labelStr=rawValue==null?'':String(rawValue);
+      const trimmed=labelStr.trim();
+      if(!trimmed) return;
+      const spend=Number(row.total_spend)||0;
+      const sales=Number(row.total_sales)||0;
+      if(spend===0 && sales===0) return;
+      const existing=bucket.get(labelStr);
+      if(existing){
+        existing.spend+=spend;
+        existing.sales+=sales;
+      }else{
+        bucket.set(labelStr,{spend,sales,rawValue});
+      }
+    });
+    return bucket;
+  };
+
+  const filterSt=getPivotFilterValues('conversionSt');
+  const filterAsin=getPivotFilterValues('conversionAsin');
+  const filterKey=filter=>{
+    if(!filter) return 'null';
+    const months=Array.isArray(filter.months)?filter.months.slice().sort():[];
+    return JSON.stringify([months, filter.start||'', filter.end||'']);
+  };
+
+  const sameFilter=filterKey(filterSt)===filterKey(filterAsin);
+  const rowsSt=runConversionQuery(filterSt);
+  const bucketSt=buildBucket(rowsSt,'st');
+  const bucketAsin=sameFilter ? buildBucket(rowsSt,'asin') : buildBucket(runConversionQuery(filterAsin),'asin');
+
+  const renderBucket=(target,map,labelSuffix,key)=>{
+    if(!target) return false;
+    if(!state.conversionPage) state.conversionPage={st:0,asin:0};
+    let workingMap=map;
+    const totalEntries=workingMap instanceof Map ? workingMap.size : 0;
+    let pageIndex=state.conversionPage[key]||0;
+    if(MAX_CONVERSION_ROWS && totalEntries>0){
+      const totalPages=Math.ceil(totalEntries/MAX_CONVERSION_ROWS);
+      if(pageIndex>=totalPages) pageIndex=Math.max(0,totalPages-1);
+    }else{
+      pageIndex=0;
+    }
+    state.conversionPage[key]=pageIndex;
+    const agg=finalizeAgg(workingMap, MAX_CONVERSION_ROWS, {page:pageIndex});
+    updateConversionNav(target, agg);
+    return renderPivotCard(target, `${baseLabel} (${labelSuffix})`, agg, true);
+  };
+
+  result.st = renderBucket(targetSt,bucketSt,'ST','st');
+  result.asin = renderBucket(targetAsin,bucketAsin,'ASIN','asin');
+  return result;
+}
+
+function hideUnusedPivotSlots(activeSlots){
+  if(!el.pivot) return;
+  Object.entries(el.pivot).forEach(([slot,target])=>{
+    if(slot==='section') return;
+    if(activeSlots.has(slot)) return;
+    if(target?.card){
+      target.card.hidden=true;
+      target.card.style.removeProperty('grid-row-end');
+    }
+    if(target) target.dimension=null;
+    if(target?.table){
+      target.table.innerHTML='';
+      target.table._pivotData=null;
+      target.table._pivotSlot=null;
+      target.table.classList.remove('has-grand-total');
+      updatePivotFootSpace(target.table);
+    }
+  });
+}
+
+function filterAdvertisedProductRows(rows, campaignValues, adgroupValues, mode){
+  if(!Array.isArray(rows) || !rows.length) return [];
+  const useCampaign=mode==='campaign';
+  const useAdGroup=mode==='adgroup';
+  const campaignList=Array.isArray(campaignValues)?campaignValues:[];
+  const adgroupList=Array.isArray(adgroupValues)?adgroupValues:[];
+  const campaignSet=useCampaign && campaignList.length?new Set(campaignList.map(value=>normalizeAdvertisedKey(value))):null;
+  const adGroupSet=useAdGroup && adgroupList.length?new Set(adgroupList.map(value=>normalizeAdvertisedKey(value))):null;
+  if(useCampaign && (!campaignSet || !campaignSet.size)) return [];
+  if(useAdGroup && (!adGroupSet || !adGroupSet.size)) return [];
+  const dedupe=new Map();
+  rows.forEach(row=>{
+    if(!row) return;
+    if(useCampaign && campaignSet && !campaignSet.has(row.campaignKey)) return;
+    if(useAdGroup && adGroupSet && !adGroupSet.has(row.adGroupKey)) return;
+    const sku=String(row.sku||'').trim();
+    const asin=String(row.asin||'').trim();
+    if(!sku && !asin) return;
+    const key=`${normalizeSkuKey(sku)}||${normalizeAsinKey(asin)}`;
+    if(!dedupe.has(key)){
+      dedupe.set(key,{sku,asin});
+    }
+  });
+  const result=Array.from(dedupe.values());
+  if(!result.length) return [];
+  result.sort((a,b)=>{
+    const skuDiff=PIVOT_LABEL_COLLATOR.compare(a.sku||'', b.sku||'');
+    if(skuDiff!==0) return skuDiff;
+    return PIVOT_LABEL_COLLATOR.compare(a.asin||'', b.asin||'');
+  });
+  return result;
+}
+function setAdvertisedProductsView(status, rows){
+  const view=el.advertisedProducts;
+  if(!view) return;
+  const {table, body, empty}=view;
+  if(table){
+    table.classList.toggle('is-loading', status==='loading');
+  }
+  if(status==='loading'){
+    if(body) body.innerHTML='<tr class="advertised-loading"><td colspan="2">Loading…</td></tr>';
+    if(table) table.hidden=false;
+    if(empty) empty.hidden=true;
+  }else if(status==='error'){
+    if(body) body.innerHTML='';
+    if(table) table.hidden=true;
+    if(empty){
+      empty.textContent='Unable to load advertised products.';
+      empty.hidden=false;
+    }
+  }else if(status==='empty'){
+    if(body) body.innerHTML='';
+    if(table) table.hidden=true;
+    if(empty){
+      empty.textContent='No advertised products for the selected filters.';
+      empty.hidden=false;
+    }
+  }else if(status==='rows'){
+    if(body){
+      const placeholder='<span class="advertised-placeholder">—</span>';
+      body.innerHTML=rows.map(row=>{
+        const sku=row?.sku?escapeHtml(row.sku):placeholder;
+        const asin=row?.asin?escapeHtml(row.asin):placeholder;
+        return `<tr><td>${sku}</td><td>${asin}</td></tr>`;
+      }).join('');
+    }
+    if(table) table.hidden=false;
+    if(empty) empty.hidden=true;
+  }
+  if(typeof schedulePivotLayout==='function'){
+    schedulePivotLayout();
+  }
+}
+
+function updateAdvertisedProductsDisplay(){
+  const view=el.advertisedProducts;
+  if(!view || !view.card) return;
+  const tracker=state.advertisedProducts;
+  if(tracker){
+    tracker.renderToken=(tracker.renderToken||0)+1;
+  }
+  const token=tracker?.renderToken||0;
+  const activeConfig=Array.isArray(PIVOT_CONFIG[state.activeTab])?PIVOT_CONFIG[state.activeTab]:[];
+  const supportsCampaign=activeConfig.some(cfg=>cfg?.slot==='campaign');
+  const supportsAdGroup=activeConfig.some(cfg=>cfg?.slot==='adGroup');
+  if(!state.hasData || (!supportsCampaign && !supportsAdGroup)){
+    view.card.hidden=true;
+    return;
+  }
+  const campaignRoot=el.dd?.campaign;
+  const adgroupRoot=el.dd?.adgroup;
+  const campaignValues=campaignRoot?ddGetSelected(campaignRoot):[];
+  const adgroupValues=adgroupRoot?ddGetSelected(adgroupRoot):[];
+  const hasCampaign=campaignValues.length>0;
+  const hasAdGroup=adgroupValues.length>0;
+  let filterMode=null;
+  const lastSlot=tracker?.lastSlot;
+  if(lastSlot==='adgroup' && hasAdGroup){
+    filterMode='adgroup';
+  }else if(lastSlot==='campaign' && hasCampaign){
+    filterMode='campaign';
+  }
+  if(!filterMode){
+    if(hasAdGroup && !hasCampaign){
+      filterMode='adgroup';
+    }else if(hasCampaign && !hasAdGroup){
+      filterMode='campaign';
+    }else if(hasCampaign && hasAdGroup){
+      filterMode='adgroup';
+    }
+  }
+  if(!filterMode){
+    if(tracker) tracker.lastSlot=null;
+    view.card.hidden=true;
+    return;
+  }
+  if(tracker) tracker.lastSlot=filterMode;
+  view.card.hidden=false;
+  setAdvertisedProductsView('loading');
+  ensureAdvertisedProductsData().then(rows=>{
+    if(state.advertisedProducts?.renderToken!==token) return;
+    const filtered=filterAdvertisedProductRows(rows, campaignValues, adgroupValues, filterMode);
+    if(filtered.length){
+      setAdvertisedProductsView('rows', filtered);
+    }else{
+      setAdvertisedProductsView('empty');
+    }
+  }).catch(()=>{
+    if(state.advertisedProducts?.renderToken!==token) return;
+    setAdvertisedProductsView('error');
+  });
+}
+
+/* ===== render & CSV ===== */
+function renderAll(){
+  const context=buildFilterContext(null);
+  const series=buildKpiSeries(context);
+  renderKPIs(computeKPIs(context), series);
+
+  const spendInfo=getSqlInfoForStateKey('spend');
+  const salesInfo=getSqlInfoForStateKey('revenue');
+  if(el.pivot?.section) el.pivot.section.dataset.mode = state.activeTab || 'overview';
+
+  const activeSlots=new Set();
+  let anyPivot=false;
+
+  const config=getPivotConfig();
+  const visibilities=config.map(({slot,column,fallback,options})=>{
+    const target=el.pivot?.[slot];
+    if(!target) return false;
+    if(target.table) target.table._pivotSlot=slot;
+    const columnDef=state.columns[column];
+    const opts=options||{};
+    const columnName=opts.displayName || columnDef?.name || fallback;
+    const columnKey=columnDef ? normalize(columnDef.name) : null;
+    target.dimension = columnKey ? {stateKey:column, columnKey, caseInsensitive:!!opts.caseInsensitive} : null;
+    const hasMetrics = spendInfo && salesInfo && columnKey;
+    const pivotFilter = getPivotFilterValues(slot);
+    const agg = hasMetrics ? buildAggSql(context, columnKey, spendInfo, salesInfo, {...opts, pivotFilter}) : null;
+    const rendered = renderPivotCard(target, columnName, agg, !!columnKey);
+    if(rendered) activeSlots.add(slot);
+    return rendered;
+  });
+  anyPivot = visibilities.some(Boolean);
+
+  if(state.activeTab==='targeting'){
+    const result=renderConversionPivots(context, spendInfo, salesInfo);
+    if(result.st) activeSlots.add('conversionSt');
+    if(result.asin) activeSlots.add('conversionAsin');
+    if(result.st || result.asin) anyPivot = true;
+  }
+
+  hideUnusedPivotSlots(activeSlots);
+
+  if(el.pivot?.section) el.pivot.section.hidden = !anyPivot;
+  updateResetButtonVisibility();
+  updatePivotFilterButtons();
+  refreshActivePivotPopup();
+  if(!skuSyncing){
+    const skuSelected=el.dd?.sku ? ddGetSelected(el.dd.sku) : [];
+    if(!skuSelected.length){
+      const asinRoot=el.dd?.targetingAsin;
+      if(asinRoot) syncSkuFilterFromAsins(ddGetSelected(asinRoot), {silent:true});
+    }
+  }
+  updateAdvertisedProductsDisplay();
+  schedulePivotLayout();
+}
+
+function onDownloadCsv(){
+  const table=state.sql?.table;
+  const columns=state.sql?.columns||[];
+  if(!table || !columns.length){ alert('No data available for export.'); return; }
+  const context=buildFilterContext(null);
+  const {sql,params}=combineWhere(context.conditions);
+  const selectList=columns.map(info=>`"${info.sqlName}"`).join(', ');
+  const rows=sqlQueryAll(`SELECT ${selectList} FROM "${table}" ${sql}`, params);
+  if(!rows.length){ alert('No rows to download for current filters.'); return; }
+  const headers=columns.map(info=>{
+    const norm=info.normalized && info.normalized.trim();
+    return norm || info.header || info.sqlName;
+  });
+  const esc=v=>{ if(v==null) return ''; const s=String(v); return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s; };
+  const head=headers.map(esc).join(',')+'\n';
+  const body=rows.map(row=>{
+    return columns.map(info=>{
+      const value=row[info.sqlName];
+      return esc(value==null?'' : value);
+    }).join(',');
+  }).join('\n');
+  const blob=new Blob([head+body],{type:'text/csv;charset=utf-8'});
+  saveAs(blob,'filtered.csv');
+}
+
+/* ===== modal controls ===== */
+function snapshotFilters(){
+  const snap={};
+  Object.entries(el.dd).forEach(([key,root])=>{
+    if(!root) return;
+    const col=state.columns[key];
+    if(col && col.aliasOf) return;
+    snap[key]=ddGetSelected(root);
+  });
+  snap.customRange={
+    active:state.customRange.active,
+    start:state.customRange.start?toInputDate(state.customRange.start):'',
+    end:state.customRange.end?toInputDate(state.customRange.end):''
+  };
+  state.snapshot=snap;
+}
+function restoreFiltersTriggerFocus(){
+  const target=state.filtersReturn;
+  state.filtersReturn=null;
+  if(target && typeof target.focus==='function'){
+    requestAnimationFrame(()=>{
+      try{ target.focus({preventScroll:true}); }
+      catch(_){ try{ target.focus(); }catch(__){} }
+    });
+  }
+}
+function restoreSnapshot(){
+  const s=state.snapshot||{};
+  Object.entries(el.dd).forEach(([key,root])=>{
+    if(!root) return;
+    const col=state.columns[key];
+    if(col && col.aliasOf) return;
+    const selected=Array.isArray(s[key])?s[key]:[];
+    root.querySelectorAll('.dd-list input[type=checkbox]').forEach(cb=>cb.checked=selected.includes(cb.value));
+    ddUpdateSummary(root);
+    ddSyncSelectAll(root);
+  });
+  if(s.customRange){
+    const start=parseInputDate(s.customRange.start);
+    const end=parseInputDate(s.customRange.end);
+    state.customRange={
+      active:!!s.customRange.active && (start||end),
+      start:start||null,
+      end:end||null
+    };
+    if(state.customRange.active) state.monthSel.clear();
+    syncCustomRangeInputs();
+    updateMonthSummary();
+  }
+  updateAllFilterOptions(null);
+  updateResetButtonVisibility();
+}
+function openFiltersModal(options={}){
+  if(!options.fromPivot) state.activePivotModal=null;
+  snapshotFilters();
+  el.modal.classList.add('open');
+  el.modal.setAttribute('aria-hidden','false');
+}
+function closeFiltersCancel(){
+  const pivotContext=state.activePivotModal;
+  state.activePivotModal=null;
+  restoreSnapshot();
+  el.modal.classList.remove('open');
+  el.modal.setAttribute('aria-hidden','true');
+  if(pivotContext){
+    updatePivotFilterButtons();
+    refreshActivePivotPopup();
+  }else{
+    resetConversionPaging();
+    renderAll();
+  }
+  restoreFiltersTriggerFocus();
+}
+function closeFiltersApply(){
+  const pivotContext=state.activePivotModal;
+  if(pivotContext){
+    const changed=applyPivotModalSelection(pivotContext);
+    restoreSnapshot();
+    el.modal.classList.remove('open');
+    el.modal.setAttribute('aria-hidden','true');
+    state.activePivotModal=null;
+    if(changed){
+      renderAll();
+    }else{
+      updatePivotFilterButtons();
+      refreshActivePivotPopup();
+    }
+    restoreFiltersTriggerFocus();
+    return;
+  }
+  state.activePivotModal=null;
+  el.modal.classList.remove('open');
+  el.modal.setAttribute('aria-hidden','true');
+  resetConversionPaging();
+  renderAll();
+  updateResetButtonVisibility();
+  restoreFiltersTriggerFocus();
+}
+function clearAllFilters(){
+  Object.values(el.dd).forEach(root=>{
+    if(!root) return;
+    root.querySelectorAll('.dd-list input[type=checkbox]').forEach(cb=>cb.checked=false);
+    ddUpdateSummary(root);
+    ddSyncSelectAll(root);
+  });
+  clearCustomRange({skipRender:true, skipFilters:true});
+  updateAllFilterOptions(null);
+  updateMonthSummary();
+  updateResetButtonVisibility();
+}
+
+function resetFiltersAndApply(){
+  if(!state.hasData) return;
+  if(!hasActiveFilters()) return;
+  state.monthSel.clear();
+  el.monthList?.querySelectorAll('input[type=checkbox]').forEach(cb=>cb.checked=false);
+  state.monthDirty=false;
+  clearCustomRange({skipRender:true, skipFilters:true});
+  updateMonthSummary();
+  if(el.monthDD) el.monthDD.classList.remove('open');
+  clearAllFilters();
+  resetConversionPaging();
+  renderAll();
+}
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dashboard equivalent to the existing "Products Search Term" view but targeted at the `Brands Campaign` dataset.  
- Make it simple to load the `Brands Campaign.xlsx` workbook or its preprocessed JSON via the built-in dataset menu.  
- Keep the same UI/feature set (pivots, KPIs, filters, advertised products) as the original dashboard.  

### Description
- Add a new file `Brands Campaign.html` created by cloning `index.html` and updating the header/title to `Brands Campaign`.  
- Update dataset defaults inside the new HTML so `DEFAULT_WORKBOOKS` contains `Brands Campaign.xlsx` and `PREPROCESSED_WORKBOOK_MAP` maps `'brands campaign.xlsx'` to `preprocessed/Brands Campaign.json`.  
- Adjust preferred sheet names and priority list to include `Brands Campaign` for automatic sheet selection.  
- Commit the new static HTML file to the repository as the dashboard for the `Brands Campaign` dataset.  

### Testing
- The new file `Brands Campaign.html` was added and committed to the repo successfully.  
- A local static server was started with `python -m http.server 8000` to serve the new HTML.  
- An automated attempt to capture a screenshot with Playwright was performed but the Chromium process crashed, so the end-to-end render check did not complete.  
- No unit or integration test suite was executed against this change (static HTML addition).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e6904dc48320b5ce48932fafd67e)