### PR TITLE
Add Brands Campaign dataset option with KPI-only view

### DIFF
--- a/index.html
+++ b/index.html
@@ -2385,7 +2385,8 @@ const state={
   activePivotModal:null,
   filtersReturn:null,
   sql:{db:null, table:'', columns:[], columnMap:new Map(), rowCount:0},
-  dataset:{type:'',file:'',label:''}
+  dataset:{type:'',file:'',label:''},
+  datasetUi:{showPivot:true, showTabs:true}
 };
 
 function updateDatasetTitle(){
@@ -2431,6 +2432,7 @@ function applyDatasetOverrides(dataset){
   const file=(dataset?.file||'').toLowerCase();
   const label=(dataset?.label||'').toLowerCase();
   const isProductsCampaign=file.includes('products campaign') || label.includes('products campaign');
+  const isBrandsCampaign=file.includes('brands campaign') || label.includes('brands campaign');
   if(isProductsCampaign){
     TAB_ORDER=TAB_ORDER.filter(tab=>tab!=='campaignPortfolio' && tab!=='targeting');
     delete PIVOT_CONFIG.campaignPortfolio;
@@ -2446,12 +2448,17 @@ function applyDatasetOverrides(dataset){
     ensureSlot('campaign','campaign','Campaign Name');
     ensureSlot('adGroup','adgroup','Ad Group Name');
   }
+  state.datasetUi={
+    showPivot:!isBrandsCampaign,
+    showTabs:!isBrandsCampaign
+  };
   updateTabButtonsForOrder(TAB_ORDER);
   if(!TAB_ORDER.includes(state.activeTab)){
     state.activeTab=TAB_ORDER[0] || 'overview';
   }
   state.lastTabIndex=TAB_ORDER.indexOf(state.activeTab);
   updateTabsUI();
+  updateDatasetSectionVisibility();
   if(state.hasData) updateAdvertisedProductsDisplay();
 }
 
@@ -2691,7 +2698,8 @@ const pivotFilterPopupState={slot:'', options:[], filtered:[], dimension:null, b
 const DEFAULT_PREPROCESSED_DATA=[];
 const DEFAULT_WORKBOOKS=[
   'Products Search Term.xlsx',
-  'Products Campaign.xlsx'
+  'Products Campaign.xlsx',
+  'https://raw.githubusercontent.com/advt/us/main/Brands Campaign.xlsx'
 ];
 const PREPROCESSED_WORKBOOK_MAP={
   'products search term.xlsx':'preprocessed/Products Search Term.json',
@@ -3634,6 +3642,13 @@ function showLoading(on, options={}){
 
 function resetKpis(){ Object.values(el.kpi||{}).forEach(node=>{ if(node) node.textContent='—'; }); lastKpiSeries=null; updateKpiSparks(null); }
 
+function updateDatasetSectionVisibility(){
+  const showPivot=state.datasetUi?.showPivot !== false;
+  const showTabs=state.datasetUi?.showTabs !== false;
+  if(el.pivot?.section) el.pivot.section.hidden = !state.hasData || !showPivot;
+  if(el.tabs?.bar) el.tabs.bar.hidden = !state.hasData || !showTabs;
+}
+
 function setHasData(has){
   state.hasData=!!has;
   if(has){
@@ -3643,11 +3658,10 @@ function setHasData(has){
   if(has){
     if(el.topLine) el.topLine.style.display='flex';
     if(el.kpis) el.kpis.hidden=false;
-    if(el.pivot?.section) el.pivot.section.hidden=false;
     if(el.openFiltersBtn) el.openFiltersBtn.style.display='inline-flex';
     if(el.dlCsv) el.dlCsv.disabled=false;
     if(el.monthsWrap) el.monthsWrap.hidden = state.monthOptions.length===0;
-    if(el.tabs?.bar) el.tabs.bar.hidden=false;
+    updateDatasetSectionVisibility();
     if(el.tipPill) el.tipPill.hidden=true;
     if(lastKpiSeries){
       const redraw=()=>updateKpiSparks(lastKpiSeries);


### PR DESCRIPTION
### Motivation
- Add the new `Brands Campaign.xlsx` dataset to the dashboard so it appears in the dataset selector and can be loaded directly from GitHub. 
- When `Brands Campaign` is selected, present KPI cards only while hiding pivot tabs/sections for that dataset until additional charts/pivots are added. 
- Preserve existing behavior and styling for the two existing datasets (`Products Search Term` and `Products Campaign`).

### Description
- Added the GitHub raw URL for `Brands Campaign.xlsx` to `DEFAULT_WORKBOOKS` so it can be loaded directly (via the existing fetch logic) as a built-in workbook option. 
- Added `state.datasetUi` and detection for `brands campaign` in `applyDatasetOverrides` to toggle `showPivot`/`showTabs` when `Brands Campaign` is active. 
- Implemented `updateDatasetSectionVisibility()` and wired it into `setHasData()` and `applyDatasetOverrides()` to hide pivot section and tab bar while keeping KPI cards visible. 
- Kept all existing dataset handling and preprocessed mapping unchanged for the other two datasets so their behavior and styling remain intact. 

### Testing
- Launched a local static server using `python -m http.server 8000`, which started successfully. 
- Ran an automated Playwright script to open the page and select the new dataset, but the Playwright run failed (timeout / browser crash) so an end-to-end screenshot could not be produced. 
- No unit tests were present for the dashboard code, and no additional automated tests were run; the change was committed (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966064f02748320b9e3e79aa5fdc5dc)