### PR TITLE
Fix Brands Campaign dataset path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2699,7 +2699,7 @@ const DEFAULT_PREPROCESSED_DATA=[];
 const DEFAULT_WORKBOOKS=[
   'Products Search Term.xlsx',
   'Products Campaign.xlsx',
-  'https://raw.githubusercontent.com/advt/us/main/Brands Campaign.xlsx'
+  'Brands Campaign.xlsx'
 ];
 const PREPROCESSED_WORKBOOK_MAP={
   'products search term.xlsx':'preprocessed/Products Search Term.json',


### PR DESCRIPTION
### Motivation
- The built-in Brands Campaign workbook was referenced via a raw GitHub URL that can 404 or be inaccessible in some deployments.  
- Pointing the default dataset to a local asset ensures the dataset loads reliably when served from the repo.  
- This reduces network dependency and avoids failures when the remote resource is unavailable.

### Description
- Update `index.html` to replace the remote URL `https://raw.githubusercontent.com/advt/us/main/Brands Campaign.xlsx` with the local filename `'Brands Campaign.xlsx'` in the `DEFAULT_WORKBOOKS` array.  
- The change ensures the app will attempt to load the local workbook asset by default.  
- No other files or dataset mappings were modified.

### Testing
- No automated tests were run on this change.
- The change is limited to a single-line update in `index.html` and is safe to deploy with standard verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966087015a48320b0f2d06edd881669)