### PR TITLE
Add 'Products Advertised Product' workbook option and enable KPI-only view

### DIFF
--- a/index.html
+++ b/index.html
@@ -2433,6 +2433,10 @@ function applyDatasetOverrides(dataset){
   const label=(dataset?.label||'').toLowerCase();
   const isProductsCampaign=file.includes('products campaign') || label.includes('products campaign');
   const isBrandsCampaign=file.includes('brands campaign') || label.includes('brands campaign');
+  const isAdvertisedProduct=file.includes('products advertised product')
+    || label.includes('products advertised product')
+    || file.includes('advertised product')
+    || label.includes('advertised product');
   if(isProductsCampaign){
     TAB_ORDER=TAB_ORDER.filter(tab=>tab!=='campaignPortfolio' && tab!=='targeting');
     delete PIVOT_CONFIG.campaignPortfolio;
@@ -2449,8 +2453,8 @@ function applyDatasetOverrides(dataset){
     ensureSlot('adGroup','adgroup','Ad Group Name');
   }
   state.datasetUi={
-    showPivot:!isBrandsCampaign,
-    showTabs:!isBrandsCampaign
+    showPivot:!(isBrandsCampaign || isAdvertisedProduct),
+    showTabs:!(isBrandsCampaign || isAdvertisedProduct)
   };
   updateTabButtonsForOrder(TAB_ORDER);
   if(!TAB_ORDER.includes(state.activeTab)){
@@ -2699,7 +2703,8 @@ const DEFAULT_PREPROCESSED_DATA=[];
 const DEFAULT_WORKBOOKS=[
   'Products Search Term.xlsx',
   'Products Campaign.xlsx',
-  'Brands Campaign.xlsx'
+  'Brands Campaign.xlsx',
+  'Products Advertised Product.xlsx'
 ];
 const PREPROCESSED_WORKBOOK_MAP={
   'products search term.xlsx':'preprocessed/Products Search Term.json',


### PR DESCRIPTION
### Motivation
- Make the newly added `Products Advertised Product.xlsx` available in the built-in dataset selector so it can be loaded directly from the repo/URL.  
- Treat the advertised product workbook as a KPI-only dataset (like `Products Search Term`) so the page shows KPI cards but does not render pivot tables yet.  
- Preserve the single-page dashboard behavior and avoid changes to the existing datasets' behavior and styling.  
- Keep the existing KPI rendering logic unchanged and only control visibility of pivots/tabs for the new dataset.

### Description
- Added `Products Advertised Product.xlsx` to the `DEFAULT_WORKBOOKS` array in `index.html` so it appears in the dataset selector and can be fetched via the same workbook loading code.  
- Implemented an `isAdvertisedProduct` check in `applyDatasetOverrides` that detects the advertised product dataset by file or label names.  
- Updated `state.datasetUi` in `applyDatasetOverrides` to set `showPivot` and `showTabs` to `false` when the advertised product dataset is active, leaving KPI cards and their rendering intact.  
- No changes were made to existing KPI computation or pivot rendering code paths for other datasets, and UI styling/behavior is preserved.

### Testing
- Started a local HTTP server with `python -m http.server 8001` to serve the app, which ran successfully.  
- Ran a headless browser script (Playwright) to open `index.html`, open the dataset menu, and capture a screenshot of the dataset selector, which completed and produced a screenshot artifact.  
- Verified the changes were staged and committed via `git` with a commit message indicating the addition.  
- No unit test suite was present or executed as part of this change; the above runtime checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696610a440a0832080fd4a35d3adaf87)