### PR TITLE
Enable pivot tables for Brands Campaign dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -2453,8 +2453,8 @@ function applyDatasetOverrides(dataset){
     ensureSlot('adGroup','adgroup','Ad Group Name');
   }
   state.datasetUi={
-    showPivot:!(isBrandsCampaign || isAdvertisedProduct),
-    showTabs:!(isBrandsCampaign || isAdvertisedProduct)
+    showPivot:!isAdvertisedProduct,
+    showTabs:!isAdvertisedProduct
   };
   updateTabButtonsForOrder(TAB_ORDER);
   if(!TAB_ORDER.includes(state.activeTab)){


### PR DESCRIPTION
### Motivation
- The Brands Campaign dashboard should include the same pivot tables as the Products Search Term dashboard when the `Brands Campaign.xlsx` workbook is selected. 
- Previously the UI hid pivot tables and tab navigation for Brands Campaign datasets, preventing pivot rendering for that file. 
- Keep advertised-product datasets unchanged and still hide pivots for those workbooks. 

### Description
- Updated `applyDatasetOverrides` to stop treating `isBrandsCampaign` as a reason to hide pivots and tabs, by changing `state.datasetUi` so `showPivot` and `showTabs` are only suppressed for advertised-product datasets. 
- The change is contained to `index.html` and preserves existing product-campaign-specific pivot adjustments. 
- No pivot generation logic was altered; enabling the UI allows the existing pivot components to render against the selected `Brands Campaign.xlsx` data. 

### Testing
- Started a local HTTP server and used a Playwright script to load `index.html`, select `Brands Campaign.xlsx`, wait for `body.has-data` and `#pivotSection` to appear, and capture a screenshot; this flow succeeded. 
- A first Playwright attempt timed out, then a re-run completed and produced `artifacts/brands-campaign-pivot.png`. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696635a8252c83209ac6050a046e3b24)