### PR TITLE
Remove Keyword Performance Pivot card from dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,22 +708,6 @@ body.has-data #tipPill{display:none !important}
       <table id="pivotTableTargetingAsin" class="pivot-table"></table>
     </div>
   </div>
-  <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingKeywordCard">
-    <div class="chart-title">
-      <span class="chart-title-text">Keyword Performance Pivot</span>
-      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingKeyword" title="Copy Keyword Performance Pivot table" aria-label="Copy Keyword Performance Pivot table">
-        <span class="pivot-copy-icon" aria-hidden="true">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
-            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
-          </svg>
-        </span>
-      </button>
-    </div>
-    <div class="pivot-body">
-      <table id="pivotTableTargetingKeyword" class="pivot-table"></table>
-    </div>
-  </div>
   <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingCatCard">
     <div class="chart-title">
       <span class="chart-title-text">Targeting CAT Performance Pivot</span>
@@ -2273,7 +2257,6 @@ const el={
     adGroup:{card:document.getElementById('pivotAdGroupCard'),table:document.getElementById('pivotTableAdGroup')},
     portfolio:{card:document.getElementById('pivotPortfolioCard'),table:document.getElementById('pivotTablePortfolio')},
     targetingAsin:{card:document.getElementById('pivotTargetingAsinCard'),table:document.getElementById('pivotTableTargetingAsin')},
-    targetingKeyword:{card:document.getElementById('pivotTargetingKeywordCard'),table:document.getElementById('pivotTableTargetingKeyword')},
     targetingCat:{card:document.getElementById('pivotTargetingCatCard'),table:document.getElementById('pivotTableTargetingCat')},
     conversionSt:{
       card:document.getElementById('pivotConversionStCard'),
@@ -2684,7 +2667,6 @@ const DEFAULT_PIVOT_CONFIG={
   ],
   targeting:[
     {slot:'targetingAsin', column:'targetingAsin', fallback:'Targeting ASIN'},
-    {slot:'targetingKeyword', column:'targeting', fallback:'Keyword', options:{displayName:'Keyword', baseFilters:[{stateKey:'tsub', values:['Keyword']}]}},
     {slot:'targetingCat', column:'targetingCat', fallback:'Targeting CAT'}
   ]
 };


### PR DESCRIPTION
### Motivation
- The dashboard should no longer display or reference the Keyword Performance Pivot in the targeting area to match the workbook state and UI requirements. 
- The change centralizes targeting pivots to ASIN and CAT and prevents the UI from attempting to render or bind a non-existent keyword pivot.

### Description
- Removed the Keyword Performance Pivot card HTML block (`pivotTargetingKeyword`) from `index.html` so the table and copy button are no longer rendered. 
- Dropped the `targetingKeyword` bindings from the `el.pivot` lookup so the UI does not try to access the removed DOM nodes. 
- Removed the `targetingKeyword` entry from `DEFAULT_PIVOT_CONFIG` so the targeting tab configuration no longer references the keyword pivot slot.

### Testing
- Launched a local server and ran a Playwright visual smoke check that captured `artifacts/keyword-pivot-removed.png`, confirming the card is no longer present (succeeded). 
- No unit or integration test suite was executed for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f51ecec8832083ddaf69a8454ae6)