### PR TITLE
Move Targeting ASIN pivot into Overall Pivots tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,7 +692,7 @@ body.has-data #tipPill{display:none !important}
       </table>
     </div>
   </div>
-  <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingAsinCard">
+  <div class="chart-card pivot-card pivot-overall-left" id="pivotTargetingAsinCard">
     <div class="chart-title">
       <span class="chart-title-text">Targeting ASIN Performance Pivot</span>
       <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingAsin" title="Copy Targeting ASIN Performance Pivot table" aria-label="Copy Targeting ASIN Performance Pivot table">
@@ -2659,14 +2659,14 @@ const DEFAULT_PIVOT_CONFIG={
     {slot:'lo', column:'tsub', fallback:'Targeting Sub Type'},
     {slot:'custType', column:'customerType', fallback:'Customer Search Term - TYPE'},
     {slot:'cat', column:'tsub2', fallback:'Targeting Sub Type2'},
-    {slot:'placement', column:'placement', fallback:'Placement'}
+    {slot:'placement', column:'placement', fallback:'Placement'},
+    {slot:'targetingAsin', column:'targetingAsin', fallback:'Targeting ASIN'}
   ],
   campaignPortfolio:[
     {slot:'campaign', column:'campaign', fallback:'Campaign Name'},
     {slot:'adGroup', column:'adgroup', fallback:'Ad Group Name'}
   ],
   targeting:[
-    {slot:'targetingAsin', column:'targetingAsin', fallback:'Targeting ASIN'},
     {slot:'targetingCat', column:'targetingCat', fallback:'Targeting CAT'}
   ]
 };


### PR DESCRIPTION
### Motivation
- Relocate the "Targeting ASIN Performance Pivot" into the Overall Pivots view so it renders with the other overall pivots instead of under the Targeting tab.

### Description
- Add `targetingAsin` to `DEFAULT_PIVOT_CONFIG.overall` and remove it from the `targeting` array so the pivot config targets the overall view (updated `index.html`).
- Change the pivot card markup for `pivotTargetingAsinCard` from `pivot-targeting-left` to `pivot-overall-left` so the card uses the overall layout and positioning (updated `index.html`).

### Testing
- Ran a quick static UI smoke test by serving the site with `python -m http.server 8000` and running a Playwright script to load `index.html` and capture `artifacts/pivot-overall.png`, which completed successfully.
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f95e58a48320936c19ae5f11a783)