### PR TITLE
Reposition Targeting ASIN pivot to right column in Overall Pivots

### DIFF
--- a/index.html
+++ b/index.html
@@ -590,6 +590,22 @@ body.has-data #tipPill{display:none !important}
       <table id="pivotTableLo" class="pivot-table"></table>
     </div>
   </div>
+  <div class="chart-card pivot-card pivot-overall-right" id="pivotTargetingAsinCard">
+    <div class="chart-title">
+      <span class="chart-title-text">Targeting ASIN Performance Pivot</span>
+      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingAsin" title="Copy Targeting ASIN Performance Pivot table" aria-label="Copy Targeting ASIN Performance Pivot table">
+        <span class="pivot-copy-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
+            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="pivot-body">
+      <table id="pivotTableTargetingAsin" class="pivot-table"></table>
+    </div>
+  </div>
   <div class="chart-card pivot-card pivot-overall-right" id="pivotCatCard">
     <div class="chart-title">
       <span class="chart-title-text">Category Performance Pivot</span>
@@ -685,22 +701,6 @@ body.has-data #tipPill{display:none !important}
         </thead>
         <tbody></tbody>
       </table>
-    </div>
-  </div>
-  <div class="chart-card pivot-card pivot-overall-left" id="pivotTargetingAsinCard">
-    <div class="chart-title">
-      <span class="chart-title-text">Targeting ASIN Performance Pivot</span>
-      <button type="button" class="pivot-action-btn pivot-copy-btn" data-copy-target="pivotTableTargetingAsin" title="Copy Targeting ASIN Performance Pivot table" aria-label="Copy Targeting ASIN Performance Pivot table">
-        <span class="pivot-copy-icon" aria-hidden="true">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-            <rect x="5" y="5" width="12" height="12" rx="3" ry="3" opacity=".45"></rect>
-            <rect x="8" y="7" width="12" height="12" rx="3" ry="3"></rect>
-          </svg>
-        </span>
-      </button>
-    </div>
-    <div class="pivot-body">
-      <table id="pivotTableTargetingAsin" class="pivot-table"></table>
     </div>
   </div>
   <div class="chart-card pivot-card pivot-targeting-left" id="pivotTargetingCatCard">


### PR DESCRIPTION
### Motivation
- Align the "Targeting ASIN Performance Pivot" visually with the targeting pivots by moving its card to the right column in the "Overall Pivots" layout while leaving pivot data and logic untouched.

### Description
- Updated `index.html` to move the `pivotTargetingAsinCard` element earlier in the markup and changed its placement class from left to right (`pivot-overall-left` → `pivot-overall-right`) so it appears to the right of the stacked targeting type/sub-type pivots.

### Testing
- No unit or integration tests were executed; the change is layout-only and committed (`git` commit message: "Reposition targeting ASIN pivot card"); an attempted headless browser screenshot using Playwright timed out and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0d7c59488320b59b3b068ab30a4d)