### PR TITLE
Move Advertised ASIN pivot to Overall tab for Products Advertised Product dataset

### DIFF
--- a/index.html
+++ b/index.html
@@ -2437,6 +2437,23 @@ function applyDatasetOverrides(dataset){
     || label.includes('products advertised product')
     || file.includes('advertised product')
     || label.includes('advertised product');
+  if(isAdvertisedProduct){
+    const overall=Array.isArray(PIVOT_CONFIG.overall) ? PIVOT_CONFIG.overall : [];
+    const targeting=Array.isArray(PIVOT_CONFIG.targeting) ? PIVOT_CONFIG.targeting : [];
+    const moved=targeting.find(entry=>entry?.slot==='targetingAsin');
+    PIVOT_CONFIG.targeting=targeting.filter(entry=>entry?.slot!=='targetingAsin');
+    if(!overall.some(entry=>entry?.slot==='targetingAsin')){
+      const next=moved ? {...moved} : {slot:'targetingAsin', column:'targetingAsin', fallback:'Advertised ASIN'};
+      next.options={...(next.options||{}), displayName:'Advertised ASIN'};
+      overall.push(next);
+    }else{
+      const entry=overall.find(cfg=>cfg?.slot==='targetingAsin');
+      if(entry){
+        entry.options={...(entry.options||{}), displayName:'Advertised ASIN'};
+      }
+    }
+    PIVOT_CONFIG.overall=overall;
+  }
   if(isProductsCampaign){
     TAB_ORDER=TAB_ORDER.filter(tab=>tab!=='campaignPortfolio' && tab!=='targeting');
     delete PIVOT_CONFIG.campaignPortfolio;


### PR DESCRIPTION
### Motivation
- For the `Products Advertised Product` dataset the advertised-ASIN pivot should appear under the Overall pivots view instead of the Targeting ASIN/CAT view so the UI surface matches the dataset semantics. 
- Ensure the pivot uses the correct display label when moved so table headers and filter UI read `Advertised ASIN`.

### Description
- Added logic inside `applyDatasetOverrides` in `index.html` to detect the `Products Advertised Product` dataset and move the `targetingAsin` pivot entry from `PIVOT_CONFIG.targeting` into `PIVOT_CONFIG.overall` while preserving existing options if present. 
- When moving the entry the code sets `options.displayName` to `Advertised ASIN` so the pivot renders with the intended label. 
- The change only affects the `Products Advertised Product` dataset branch and leaves other dataset configurations untouched.

### Testing
- Started a local server with `python -m http.server 8000` and the server launched successfully. 
- Ran a Playwright script that navigated to `http://127.0.0.1:8000/index.html` and captured a screenshot (`artifacts/pivots.png`) to validate the UI; the script completed successfully. 
- No automated unit tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a27feac2c83208a2bce27463286a4)