### PR TITLE
Split Products Search Term into 2025/2026 and add year selection modal

### DIFF
--- a/AUTO_UPDATE_INSTRUCTIONS.md
+++ b/AUTO_UPDATE_INSTRUCTIONS.md
@@ -24,10 +24,11 @@ cp tools/local_pipeline_config.example.json tools/local_pipeline_config.json
 Open `tools/local_pipeline_config.json` and update the `excel_path` for each
 workbook. **Do not change** the `output_path` values; they must stay:
 
-- `preprocessed/Products Search Term.json`
+- `preprocessed/Products Search Term 2025.json`
+- `preprocessed/Products Search Term 2026.json`
 - `preprocessed/Products Campaign.json`
 
-Make sure the sheet names match exactly (e.g., `"Products Search Term"`).
+Make sure the sheet names match exactly for each workbook (e.g., `"Sheet1"`).
 
 ## 3) Run once to verify
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ You can pass a custom output path or select a specific sheet using the
 Use `tools/local_pipeline.py` to read the Excel files from your PC, export the
 exact JSON files used by the dashboard, and automatically commit + push them to
 GitHub. The dashboard will continue to read the same files at the same paths
-(`preprocessed/Products Search Term.json` and
+(`preprocessed/Products Search Term 2025.json`,
+`preprocessed/Products Search Term 2026.json`, and
 `preprocessed/Products Campaign.json`).
 
 1. Install dependencies:

--- a/auto_update_dashboard.py
+++ b/auto_update_dashboard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Continuously publish the Products Search Term worksheet for GitHub Pages."""
+"""Continuously publish the Products Search Term worksheets for GitHub Pages."""
 from __future__ import annotations
 
 import json
@@ -22,9 +22,7 @@ from watchdog.observers import Observer
 # Configurable settings
 # =====================
 REPO_ROOT = Path(__file__).resolve().parent
-EXCEL_PATH = REPO_ROOT / "Products Search Term.xlsx"
-SHEET_NAME = "Sheet 1"
-OUTPUT_PATH = REPO_ROOT / "preprocessed/Products Search Term.json"
+DEFAULT_SHEET_NAME = "Sheet 1"
 HEADER_ROW_INDEX = 1
 CONFIG_PATH = REPO_ROOT / "tools/local_pipeline_config.json"
 DEBOUNCE_SECONDS = 2.5
@@ -40,6 +38,22 @@ class WorkbookConfig:
     sheet_name: str
     output_path: Path
     header_row_index: int
+
+
+DEFAULT_WORKBOOK_CONFIGS = (
+    WorkbookConfig(
+        excel_path=REPO_ROOT / "Products Search Term 2025.xlsx",
+        sheet_name=DEFAULT_SHEET_NAME,
+        output_path=REPO_ROOT / "preprocessed/Products Search Term 2025.json",
+        header_row_index=HEADER_ROW_INDEX,
+    ),
+    WorkbookConfig(
+        excel_path=REPO_ROOT / "Products Search Term 2026.xlsx",
+        sheet_name=DEFAULT_SHEET_NAME,
+        output_path=REPO_ROOT / "preprocessed/Products Search Term 2026.json",
+        header_row_index=HEADER_ROW_INDEX,
+    ),
+)
 
 
 class DebouncedRunner:
@@ -83,23 +97,22 @@ class ExcelChangeHandler(FileSystemEventHandler):
             self.runner.trigger()
 
 
-def load_config_from_file(config_path: Path) -> Optional[WorkbookConfig]:
+def load_config_from_file(config_path: Path) -> list[WorkbookConfig]:
     if not config_path.exists():
-        return None
+        return []
     try:
         with config_path.open("r", encoding="utf-8") as fp:
             payload = json.load(fp)
     except json.JSONDecodeError:
         logging.warning("Config file is not valid JSON: %s", config_path)
-        return None
+        return []
     workbooks = payload.get("workbooks", [])
     if not isinstance(workbooks, list):
         logging.warning("Config file missing 'workbooks' list: %s", config_path)
-        return None
+        return []
+    configs: list[WorkbookConfig] = []
     for entry in workbooks:
-        sheet_name = str(entry.get("sheet_name", "")).strip()
-        if sheet_name.lower() != SHEET_NAME.lower():
-            continue
+        sheet_name = str(entry.get("sheet_name", DEFAULT_SHEET_NAME)).strip() or DEFAULT_SHEET_NAME
         excel_path_raw = str(entry.get("excel_path", "")).strip()
         output_path_raw = str(entry.get("output_path", "")).strip()
         header_row_index = int(entry.get("header_row_index", HEADER_ROW_INDEX))
@@ -109,25 +122,22 @@ def load_config_from_file(config_path: Path) -> Optional[WorkbookConfig]:
         output_path = Path(output_path_raw)
         if not output_path.is_absolute():
             output_path = REPO_ROOT / output_path
-        return WorkbookConfig(
-            excel_path=excel_path,
-            sheet_name=SHEET_NAME,
-            output_path=output_path,
-            header_row_index=header_row_index,
+        configs.append(
+            WorkbookConfig(
+                excel_path=excel_path,
+                sheet_name=sheet_name,
+                output_path=output_path,
+                header_row_index=header_row_index,
+            )
         )
-    return None
+    return configs
 
 
-def resolve_workbook_config() -> WorkbookConfig:
-    config = load_config_from_file(CONFIG_PATH)
-    if config is not None:
-        return config
-    return WorkbookConfig(
-        excel_path=EXCEL_PATH,
-        sheet_name=SHEET_NAME,
-        output_path=OUTPUT_PATH,
-        header_row_index=HEADER_ROW_INDEX,
-    )
+def resolve_workbook_configs() -> list[WorkbookConfig]:
+    configs = load_config_from_file(CONFIG_PATH)
+    if configs:
+        return configs
+    return list(DEFAULT_WORKBOOK_CONFIGS)
 
 
 def normalize_cell(value: object) -> object:
@@ -226,11 +236,13 @@ def write_json_output(config: WorkbookConfig, rows: Iterable[list[object]]) -> N
     logging.info("Wrote %s", config.output_path)
 
 
-def git_publish(output_path: Path) -> None:
-    rel_path = str(output_path)
-    subprocess.run(["git", "add", "--", rel_path], check=True)
+def git_publish(output_paths: Iterable[Path]) -> None:
+    rel_paths = [str(output_path) for output_path in output_paths]
+    if not rel_paths:
+        return
+    subprocess.run(["git", "add", "--", *rel_paths], check=True)
     status = subprocess.check_output(
-        ["git", "status", "--porcelain", "--", rel_path],
+        ["git", "status", "--porcelain", "--", *rel_paths],
         text=True,
     ).strip()
     if not status:
@@ -244,40 +256,51 @@ def git_publish(output_path: Path) -> None:
 
 
 def refresh_dashboard() -> None:
-    config = resolve_workbook_config()
-    try:
-        rows = read_worksheet(config)
-    except FileNotFoundError as exc:
-        logging.warning("%s", exc)
-        return
-    except ValueError as exc:
-        logging.warning("%s", exc)
-        return
+    configs = resolve_workbook_configs()
+    output_paths: list[Path] = []
+    for config in configs:
+        try:
+            rows = read_worksheet(config)
+        except FileNotFoundError as exc:
+            logging.warning("%s", exc)
+            continue
+        except ValueError as exc:
+            logging.warning("%s", exc)
+            continue
 
-    if not rows:
-        logging.warning("Sheet is empty")
-        return
+        if not rows:
+            logging.warning("Sheet is empty for %s", config.excel_path)
+            continue
 
-    write_json_output(config, rows)
+        write_json_output(config, rows)
+        output_paths.append(config.output_path)
+    if not output_paths:
+        return
     try:
-        git_publish(config.output_path)
+        git_publish(output_paths)
     except subprocess.CalledProcessError as exc:
         logging.error("Git publish failed: %s", exc)
 
 
-def watch_with_watchdog(config: WorkbookConfig) -> Observer:
+def watch_with_watchdog(configs: Iterable[WorkbookConfig]) -> Observer:
     runner = DebouncedRunner(DEBOUNCE_SECONDS, refresh_dashboard)
-    handler = ExcelChangeHandler({config.excel_path, CONFIG_PATH}, runner)
+    watch_paths = {CONFIG_PATH}
+    watch_dirs = {CONFIG_PATH.parent}
+    for config in configs:
+        watch_paths.add(config.excel_path)
+        watch_dirs.add(config.excel_path.parent)
+    handler = ExcelChangeHandler(watch_paths, runner)
     observer = Observer()
-    watch_dirs = {config.excel_path.parent, CONFIG_PATH.parent}
     for watch_dir in watch_dirs:
         observer.schedule(handler, str(watch_dir), recursive=False)
     observer.start()
     return observer
 
 
-def poll_for_changes(config: WorkbookConfig) -> None:
-    watch_paths = {config.excel_path, CONFIG_PATH}
+def poll_for_changes(configs: Iterable[WorkbookConfig]) -> None:
+    watch_paths = {CONFIG_PATH}
+    for config in configs:
+        watch_paths.add(config.excel_path)
     mtimes: dict[Path, float] = {}
     for path in watch_paths:
         if path.exists():
@@ -301,15 +324,19 @@ def main() -> None:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
     )
-    config = resolve_workbook_config()
-    logging.info("Watching %s", config.excel_path)
+    configs = resolve_workbook_configs()
+    if configs:
+        watched = ", ".join(str(config.excel_path) for config in configs)
+        logging.info("Watching %s", watched)
+    else:
+        logging.info("No workbooks configured to watch.")
     refresh_dashboard()
 
     try:
-        observer = watch_with_watchdog(config)
+        observer = watch_with_watchdog(configs)
     except Exception as exc:
         logging.warning("watchdog unavailable (%s); falling back to polling", exc)
-        poll_for_changes(config)
+        poll_for_changes(configs)
         return
 
     last_config_mtime = CONFIG_PATH.stat().st_mtime if CONFIG_PATH.exists() else 0.0
@@ -323,8 +350,8 @@ def main() -> None:
                     logging.info("Config updated; reloading watch paths.")
                     observer.stop()
                     observer.join()
-                    config = resolve_workbook_config()
-                    observer = watch_with_watchdog(config)
+                    configs = resolve_workbook_configs()
+                    observer = watch_with_watchdog(configs)
     except KeyboardInterrupt:
         logging.info("Stopping watcher.")
     finally:

--- a/index.html
+++ b/index.html
@@ -377,6 +377,12 @@ body.has-data #tipPill{display:none !important}
 .filter label::after{content:"";display:block;width:18px;height:2px;border-radius:999px;background:var(--accent);margin-top:4px}
 .filter.is-highlighted{outline:2px solid color-mix(in srgb,var(--accent) 65%, transparent);outline-offset:2px;animation:filterPulse 1.2s ease-in-out;box-shadow:0 0 0 6px color-mix(in srgb,var(--accent) 25%, transparent)}
 @keyframes filterPulse{0%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 28%, transparent);}50%{box-shadow:0 0 0 12px color-mix(in srgb,var(--accent) 18%, transparent);}100%{box-shadow:0 0 0 0 color-mix(in srgb,var(--accent) 0%, transparent);}}
+.year-modal-body{display:grid;gap:14px}
+.year-modal-text{margin:0;color:var(--muted);font-weight:600}
+.year-modal-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px}
+.year-option{padding:12px 14px;border-radius:12px;border:1px solid var(--border);background:var(--panel);color:var(--text);font-weight:700;letter-spacing:.4px;text-transform:uppercase;cursor:pointer;transition:transform .15s ease, box-shadow .2s ease, border-color .2s ease}
+.year-option:hover{transform:translateY(-1px);border-color:color-mix(in srgb,var(--accent) 50%, var(--border));box-shadow:0 10px 20px rgba(15,23,42,.2)}
+.year-option:focus-visible{outline:2px solid color-mix(in srgb,var(--accent) 75%, transparent);outline-offset:2px}
 
 /* Multi-select */
 .dd{position:relative}
@@ -823,6 +829,23 @@ body.has-data #tipPill{display:none !important}
       <button id="clearAll" class="btn-outline">Clear All</button>
       <button id="cancelFilters" class="btn-outline">Cancel</button>
       <button id="applyFilters" class="btn-primary">Apply</button>
+    </div>
+  </div>
+</div>
+
+<!-- Products Search Term Year Modal -->
+<div id="yearSelectModal" class="modal" aria-hidden="true" role="dialog" aria-label="Select Products Search Term year">
+  <div class="modal-card">
+    <div class="modal-head">
+      <h3>Products Search Term</h3>
+      <button id="closeYearSelect" class="btn-outline" title="Close">✕</button>
+    </div>
+    <div class="year-modal-body">
+      <p class="year-modal-text">Select the year to load the Products Search Term dashboard.</p>
+      <div id="yearSelectOptions" class="year-modal-options">
+        <button type="button" class="year-option" data-search-term-year="2025">2025</button>
+        <button type="button" class="year-option" data-search-term-year="2026">2026</button>
+      </div>
     </div>
   </div>
 </div>
@@ -2327,6 +2350,11 @@ const el={
   applyFiltersBtn:document.getElementById('applyFilters'),
   clearAllBtn:document.getElementById('clearAll'),
   filters:document.getElementById('filtersSection'),
+  searchTermYear:{
+    modal:document.getElementById('yearSelectModal'),
+    close:document.getElementById('closeYearSelect'),
+    options:document.getElementById('yearSelectOptions')
+  },
   themeBtn:document.getElementById('themeBtn'),
   empty:document.getElementById('emptyState'),
   emptyDatasetOptions:document.getElementById('emptyDatasetOptions'),
@@ -2384,6 +2412,7 @@ const state={
   activePivotPopup:null,
   activePivotModal:null,
   filtersReturn:null,
+  yearPromptReturn:null,
   sql:{db:null, table:'', columns:[], columnMap:new Map(), rowCount:0},
   dataset:{type:'',file:'',label:''},
   datasetUi:{showPivot:true, showTabs:true}
@@ -2513,7 +2542,9 @@ function updateDatasetMenuActive(){
     menu.list.querySelectorAll('[data-dataset-id]').forEach(item=>{
       const type=item.dataset.datasetType||'';
       const file=item.dataset.datasetFile||'';
-      const isActive=!!dataset.file && dataset.type===type && dataset.file===file;
+      const isActive=type==='yearPrompt'
+        ? isProductsSearchTermDataset(dataset)
+        : (!!dataset.file && dataset.type===type && dataset.file===file);
       item.classList.toggle('is-active', isActive);
       item.setAttribute('aria-checked', isActive?'true':'false');
     });
@@ -2522,7 +2553,9 @@ function updateDatasetMenuActive(){
     el.emptyDatasetOptions.querySelectorAll('[data-dataset-id]').forEach(button=>{
       const type=button.dataset.datasetType||'';
       const file=button.dataset.datasetFile||'';
-      const isActive=!!dataset.file && dataset.type===type && dataset.file===file;
+      const isActive=type==='yearPrompt'
+        ? isProductsSearchTermDataset(dataset)
+        : (!!dataset.file && dataset.type===type && dataset.file===file);
       button.classList.toggle('is-active', isActive);
       button.setAttribute('aria-pressed', isActive?'true':'false');
     });
@@ -2577,11 +2610,55 @@ function toggleDatasetMenu(){
   else openDatasetMenu();
 }
 
-async function handleDatasetSelection(type,file,label){
+function isSearchTermYearModalOpen(){
+  const modal=el.searchTermYear?.modal;
+  return !!(modal && modal.classList.contains('open'));
+}
+
+function openSearchTermYearModal(triggerEl){
+  const modal=el.searchTermYear?.modal;
+  if(!modal || isSearchTermYearModalOpen()) return;
+  state.yearPromptReturn=triggerEl || document.activeElement;
+  modal.classList.add('open');
+  modal.setAttribute('aria-hidden','false');
+  const firstOption=modal.querySelector('[data-search-term-year]');
+  if(firstOption){
+    requestAnimationFrame(()=>{ try{ firstOption.focus({preventScroll:true}); }catch(_){ } });
+  }
+}
+
+function closeSearchTermYearModal(options={restoreFocus:true}){
+  const modal=el.searchTermYear?.modal;
+  if(!modal || !isSearchTermYearModalOpen()) return;
+  modal.classList.remove('open');
+  modal.setAttribute('aria-hidden','true');
+  if(options.restoreFocus){
+    const target=state.yearPromptReturn;
+    state.yearPromptReturn=null;
+    if(target && typeof target.focus==='function'){
+      requestAnimationFrame(()=>{ try{ target.focus({preventScroll:true}); }catch(_){ } });
+    }
+  }else{
+    state.yearPromptReturn=null;
+  }
+}
+
+async function selectSearchTermYear(year){
+  const match=PRODUCTS_SEARCH_TERM_YEARS.find(option=>option.year===String(year));
+  if(!match) return;
+  closeSearchTermYearModal({restoreFocus:false});
+  await handleDatasetSelection('workbook', match.file, match.label);
+}
+
+async function handleDatasetSelection(type,file,label,triggerEl){
   const datasetType=type||'';
   const datasetFile=file||'';
   const datasetLabel=label || formatDatasetLabelFromFile(datasetFile);
   if(!datasetType || !datasetFile) return;
+  if(datasetType==='yearPrompt'){
+    openSearchTermYearModal(triggerEl);
+    return;
+  }
   try{
     showLoading(true);
     if(datasetType==='workbook'){
@@ -2660,7 +2737,7 @@ async function onDatasetMenuClick(event){
   const file=button.dataset.datasetFile||'';
   const label=button.dataset.datasetLabel || formatDatasetLabelFromFile(file);
   closeDatasetMenu(false);
-  await handleDatasetSelection(type,file,label);
+  await handleDatasetSelection(type,file,label,button);
 }
 const DEFAULT_TAB_ORDER=['overview','overall','campaignPortfolio','targeting'];
 let TAB_ORDER=DEFAULT_TAB_ORDER.slice();
@@ -2717,14 +2794,19 @@ const FILTER_BACKFILL_CHUNK_SIZE=3;
 let filterBackfillToken=0;
 const pivotFilterPopupState={slot:'', options:[], filtered:[], dimension:null, button:null, displayName:'', search:'', mode:'dimension', dateTab:'months'};
 const DEFAULT_PREPROCESSED_DATA=[];
+const PRODUCTS_SEARCH_TERM_LABEL='Products Search Term';
+const PRODUCTS_SEARCH_TERM_YEARS=[
+  {year:'2025', file:'Products Search Term 2025.xlsx', label:'Products Search Term 2025'},
+  {year:'2026', file:'Products Search Term 2026.xlsx', label:'Products Search Term 2026'}
+];
 const DEFAULT_WORKBOOKS=[
-  'Products Search Term.xlsx',
   'Products Campaign.xlsx',
   'Brands Campaign.xlsx',
   'Products Advertised Product.xlsx'
 ];
 const PREPROCESSED_WORKBOOK_MAP={
-  'products search term.xlsx':'preprocessed/Products Search Term.json',
+  'products search term 2025.xlsx':'preprocessed/Products Search Term 2025.json',
+  'products search term 2026.xlsx':'preprocessed/Products Search Term 2026.json',
   'products campaign.xlsx':'preprocessed/Products Campaign.json'
 };
 const API_BASE_URL=(typeof window!=='undefined' && window.PRODUCTS_SEARCH_TERM_API_BASE)
@@ -2754,8 +2836,26 @@ function createDatasetId(type,file){
   return `${type||''}:${(file||'').toLowerCase()}`;
 }
 
+function getProductsSearchTermPromptOption(){
+  return {
+    id:createDatasetId('yearPrompt', PRODUCTS_SEARCH_TERM_LABEL),
+    type:'yearPrompt',
+    file:PRODUCTS_SEARCH_TERM_LABEL,
+    label:PRODUCTS_SEARCH_TERM_LABEL,
+    meta:'Workbook'
+  };
+}
+
+function isProductsSearchTermDataset(dataset){
+  const label=String(dataset?.label||'').trim().toLowerCase();
+  const file=String(dataset?.file||'').trim().toLowerCase();
+  return label.startsWith('products search term') || file.startsWith('products search term ');
+}
+
 function getBuiltinDatasetOptions(){
   const options=[];
+  const searchTermOption=getProductsSearchTermPromptOption();
+  if(searchTermOption) options.push(searchTermOption);
   if(Array.isArray(DEFAULT_WORKBOOKS)){
     DEFAULT_WORKBOOKS.forEach(file=>{
       const trimmed=typeof file==='string'?file.trim():'';
@@ -2827,7 +2927,7 @@ async function onEmptyDatasetOptionClick(event){
   const file=button.dataset.datasetFile||'';
   const label=button.dataset.datasetLabel || formatDatasetLabelFromFile(file);
   if(isDatasetMenuOpen()) closeDatasetMenu(false);
-  await handleDatasetSelection(type,file,label);
+  await handleDatasetSelection(type,file,label,button);
 }
 
 function ensureAsinSkuMap(){
@@ -3551,6 +3651,16 @@ function boot(){
   el.applyFiltersBtn.addEventListener('click', closeFiltersApply);
   el.clearAllBtn.addEventListener('click', clearAllFilters);
   if(el.resetFiltersBtn) el.resetFiltersBtn.addEventListener('click', resetFiltersAndApply);
+  if(el.searchTermYear?.close) el.searchTermYear.close.addEventListener('click', ()=>closeSearchTermYearModal());
+  if(el.searchTermYear?.options) el.searchTermYear.options.addEventListener('click', ev=>{
+    const button=ev.target.closest?.('[data-search-term-year]');
+    if(!button) return;
+    ev.preventDefault();
+    selectSearchTermYear(button.dataset.searchTermYear);
+  });
+  if(el.searchTermYear?.modal) el.searchTermYear.modal.addEventListener('click', ev=>{
+    if(ev.target===el.searchTermYear.modal) closeSearchTermYearModal();
+  });
   const monthControl=el.monthDD.querySelector('.dd-control');
   monthControl.addEventListener('click', ()=>{
     const wasOpen=el.monthDD.classList.contains('open');
@@ -3624,6 +3734,12 @@ function boot(){
 
   document.addEventListener('keydown', (ev)=>{
     if(ev.key==='Escape' || ev.key==='Esc'){
+      if(isSearchTermYearModalOpen()){
+        closeSearchTermYearModal();
+        ev.stopPropagation();
+        ev.preventDefault();
+        return;
+      }
       if(isDatasetMenuOpen()){
         if(closeDatasetMenu()){
           ev.stopPropagation();

--- a/tools/local_pipeline_config.example.json
+++ b/tools/local_pipeline_config.example.json
@@ -2,11 +2,19 @@
   "commit_message": "Update preprocessed dashboard data",
   "workbooks": [
     {
-      "name": "products-search-term",
-      "excel_path": "C:/path/to/Products Search Term.xlsx",
+      "name": "products-search-term-2025",
+      "excel_path": "C:/path/to/Products Search Term 2025.xlsx",
       "sheet_name": "Sheet1",
-      "output_path": "preprocessed/Products Search Term.json",
-      "csv_output_path": "preprocessed/Products Search Term.csv",
+      "output_path": "preprocessed/Products Search Term 2025.json",
+      "csv_output_path": "preprocessed/Products Search Term 2025.csv",
+      "header_row_index": 1
+    },
+    {
+      "name": "products-search-term-2026",
+      "excel_path": "C:/path/to/Products Search Term 2026.xlsx",
+      "sheet_name": "Sheet1",
+      "output_path": "preprocessed/Products Search Term 2026.json",
+      "csv_output_path": "preprocessed/Products Search Term 2026.csv",
       "header_row_index": 1
     },
     {


### PR DESCRIPTION
### Motivation
- The combined "Products Search Term" workbook was split into two year-specific workbooks, and the UI must let the user choose which year to view while preserving the previous dashboards' layout and behavior.

### Description
- Added a year selection modal to `index.html` (`#yearSelectModal`) and styles (`.year-option`) to prompt the user when they choose the Products Search Term dataset.
- Updated the dataset menu logic to expose a `yearPrompt` option and to open the modal when the Products Search Term entry is selected, with handlers to load either `Products Search Term 2025.xlsx` or `Products Search Term 2026.xlsx` based on the choice.
- Reworked built-in workbook mappings and preprocessed file map in `index.html` to reference `Products Search Term 2025/2026` JSON outputs and to treat the prompt as a special dataset option.
- Extended `auto_update_dashboard.py` to support multiple year-specific workbooks by loading configs for both 2025 and 2026, generating separate preprocessed JSON files, and publishing them together; also updated the example pipeline config and docs to reflect the two output files.

### Testing
- Started a local static server with `python -m http.server 8000` and verified `index.html` is reachable via `curl` (HTTP 200), which succeeded.
- Attempted automated UI verification with Playwright to open the dataset menu and trigger the year modal, but the Playwright runs timed out/failed to interact in this environment (attempts reported timeouts / Not Found responses), so the UI interaction test did not complete successfully.
- Ran repository searches to validate updated mappings and references for `Products Search Term 2025/2026` across `index.html`, `auto_update_dashboard.py`, and docs, which confirmed the intended replacements/insertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b24bda44083209ec1e18ccc7019cc)