### PR TITLE
Add login/authentication: login page, auth helpers, and users.json

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,57 @@
+const AUTH_KEY = "advtus-auth";
+const USER_KEY = "advtus-user";
+const USERS_URL = "users.json";
+
+function isAuthenticated() {
+  return sessionStorage.getItem(AUTH_KEY) === "true";
+}
+
+function requireAuth() {
+  if (!isAuthenticated()) {
+    window.location.href = "login.html";
+  }
+}
+
+function logout() {
+  sessionStorage.removeItem(AUTH_KEY);
+  sessionStorage.removeItem(USER_KEY);
+  window.location.href = "login.html";
+}
+
+async function hashPassword(password, salt) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${salt}${password}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function authenticateUser(email, password) {
+  const response = await fetch(USERS_URL, { cache: "no-store" });
+  if (!response.ok) {
+    return { success: false, message: "Unable to load user list." };
+  }
+  const payload = await response.json();
+  const users = Array.isArray(payload.users) ? payload.users : [];
+  const match = users.find(
+    (user) => user.email.toLowerCase() === email.toLowerCase()
+  );
+  if (!match) {
+    return { success: false, message: "Invalid email or password." };
+  }
+  const computedHash = await hashPassword(password, match.salt);
+  if (computedHash !== match.passwordHash) {
+    return { success: false, message: "Invalid email or password." };
+  }
+  sessionStorage.setItem(AUTH_KEY, "true");
+  sessionStorage.setItem(USER_KEY, match.email);
+  return { success: true };
+}
+
+window.advtAuth = {
+  authenticateUser,
+  isAuthenticated,
+  requireAuth,
+  logout,
+};

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
 <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.9.0/sql-wasm.js"></script>
+<script src="auth.js"></script>
+<script>
+  if (window.advtAuth) {
+    window.advtAuth.requireAuth();
+  }
+</script>
 
 <style>
 :root{
@@ -462,6 +468,7 @@ body.has-data #tipPill{display:none !important}
     <input id="fileInput" type="file" accept=".xlsx,.xls" hidden />
     <button id="downloadCsvBtn" class="btn-primary btn-success" disabled>Download CSV</button>
     <button id="themeBtn" class="btn-mode" title="Toggle dark/light" aria-label="Toggle theme"><span class="icon">🌙</span></button>
+    <button id="logoutBtn" class="btn-outline">Logout</button>
   </div>
 </header>
 
@@ -852,6 +859,11 @@ body.has-data #tipPill{display:none !important}
 
 <script>
 'use strict';
+
+const logoutBtn = document.getElementById('logoutBtn');
+if (logoutBtn && window.advtAuth) {
+  logoutBtn.addEventListener('click', () => window.advtAuth.logout());
+}
 
 let sqlLibPromise=null;
 let sqlReadyPromise=null;

--- a/login.html
+++ b/login.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Login | Search Terms Analytics</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root{
+      --bg:#0f1216; --panel:#161b22; --text:#e7ecf3; --muted:#9aa6b2; --accent:#2563eb;
+      --danger:#ef4444; --border:#273043; --shadow:0 12px 32px rgba(0,0,0,.35);
+    }
+    *{box-sizing:border-box}
+    body{margin:0;font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial,"Noto Sans";color:var(--text);background:var(--bg);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+    .login-card{width:min(420px,100%);background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:28px 26px;box-shadow:var(--shadow);display:flex;flex-direction:column;gap:18px}
+    h1{margin:0;font-size:22px}
+    p{margin:0;color:var(--muted)}
+    label{font-weight:600;font-size:13px;margin-bottom:6px;display:block}
+    input{width:100%;padding:12px 14px;border-radius:12px;border:1px solid var(--border);background:#0f141b;color:var(--text);font-size:14px}
+    input:focus{outline:2px solid var(--accent);border-color:var(--accent)}
+    .field{display:flex;flex-direction:column;gap:6px}
+    button{border:0;border-radius:12px;padding:12px 14px;background:linear-gradient(180deg,var(--accent),#1d4ed8);color:#fff;font-weight:700;cursor:pointer;transition:transform .12s ease, box-shadow .2s ease;box-shadow:0 10px 24px rgba(37,99,235,.25)}
+    button:hover{transform:translateY(-1px)}
+    .error{color:var(--danger);font-weight:600;min-height:20px}
+  </style>
+</head>
+<body>
+  <main class="login-card" aria-labelledby="login-title">
+    <div>
+      <h1 id="login-title">Sign in</h1>
+      <p>Use your approved email credentials to access the dashboard.</p>
+    </div>
+    <form id="loginForm">
+      <div class="field">
+        <label for="email">Email</label>
+        <input id="email" name="email" type="email" autocomplete="username" required />
+      </div>
+      <div class="field">
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required />
+      </div>
+      <p id="loginError" class="error" role="alert" aria-live="polite"></p>
+      <button type="submit">Login</button>
+    </form>
+  </main>
+
+  <script src="auth.js"></script>
+  <script>
+    const form = document.getElementById("loginForm");
+    const errorEl = document.getElementById("loginError");
+
+    if (window.advtAuth?.isAuthenticated()) {
+      window.location.href = "index.html";
+    }
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      errorEl.textContent = "";
+      const email = document.getElementById("email").value.trim();
+      const password = document.getElementById("password").value;
+      if (!email || !password) {
+        errorEl.textContent = "Please enter your email and password.";
+        return;
+      }
+      const result = await window.advtAuth.authenticateUser(email, password);
+      if (!result.success) {
+        errorEl.textContent = result.message || "Login failed.";
+        return;
+      }
+      window.location.href = "index.html";
+    });
+  </script>
+</body>
+</html>

--- a/users.json
+++ b/users.json
@@ -1,0 +1,29 @@
+{
+  "users": [
+    {
+      "email": "uss1@simondstore.com",
+      "salt": "16816f2360caf6a4",
+      "passwordHash": "e478db86475367209138b00744eaaf9b52afe8415e8a3583a46bb98f043c732e"
+    },
+    {
+      "email": "uss12@simondstore.com",
+      "salt": "d13d45a7d93e5815",
+      "passwordHash": "586a3d8f3ef627bb4851330ba091f6064e1546b8e485dbeb1136b709944057b7"
+    },
+    {
+      "email": "uss3@simondstore.com",
+      "salt": "5edd3879c2e3dc07",
+      "passwordHash": "7577cec1c79acf659a1d04d76d0ec3e3b14831e501b600e423f82f500e08c799"
+    },
+    {
+      "email": "uca6@simondstore.com",
+      "salt": "32c98f264edcfbfd",
+      "passwordHash": "13ec8cfe24c976ba4743fa2d0cba0101e14b37d05a21648cb13987879b20dc26"
+    },
+    {
+      "email": "uss13@simondstore.com",
+      "salt": "3304fc8ef9e57476",
+      "passwordHash": "09ac85c095a029712172067cd84e87c571c23e1ef2a0bb876a8e288df5a78816"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Add a gated login flow so the dashboard cannot be accessed without authentication.
- Store approved users with salted password hashes rather than plaintext credentials.
- Provide a simple client-side session mechanism and logout to remember and clear login state.

### Description
- Add `auth.js` which implements `authenticateUser`, `hashPassword` (SHA-256 + per-user salt via Web Crypto), `isAuthenticated`, `requireAuth`, and `logout`, and exposes them on `window.advtAuth`.
- Add `users.json` containing the provided emails with generated per-user `salt` and `passwordHash` (salted SHA-256) to validate credentials client-side.
- Add `login.html` with an email/password form that calls `advtAuth.authenticateUser`, shows errors on failure, and redirects to `index.html` on success.
- Protect the dashboard by injecting `auth.js` into `index.html` and calling `advtAuth.requireAuth()` at load, add a `Logout` button to the header wired to `advtAuth.logout()`, and persist auth state in `sessionStorage`.

### Testing
- Launched a static server with `python -m http.server 8000` and confirmed the server started successfully.
- Ran a headless Playwright script to navigate to `http://127.0.0.1:8000/login.html` and capture a screenshot of the login page, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697201ac3fb08320a800c75355607670)