### PR TITLE
Require year selection before loading SKU WISE AD SPEND

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@ body.has-data #tipPill{display:none !important}
 <div id="skuYearSelectModal" class="modal" aria-hidden="true" role="dialog" aria-label="Select SKU Wise Ad Spend year">
   <div class="modal-card">
     <div class="modal-head">
-      <h3>SKU WISE AD SPEND</h3>
+      <h3>Select Year</h3>
       <button id="closeSkuYearSelect" class="btn-outline" title="Close">✕</button>
     </div>
     <div class="year-modal-body">
@@ -2448,6 +2448,7 @@ const state={
   filtersReturn:null,
   yearPromptReturn:null,
   skuYearPromptReturn:null,
+  selectedYear:null,
   sql:{db:null, table:'', columns:[], columnMap:new Map(), rowCount:0},
   dataset:{type:'',file:'',label:''},
   datasetUi:{showPivot:true, showTabs:true}
@@ -2729,8 +2730,15 @@ function closeSkuAdSpendYearModal(options={restoreFocus:true}){
 async function selectSkuAdSpendYear(year){
   const match=SKU_WISE_AD_SPEND_YEARS.find(option=>option.year===String(year));
   if(!match) return;
+  state.selectedYear=match.year;
   closeSkuAdSpendYearModal({restoreFocus:false});
   await handleDatasetSelection('workbook', match.file, match.label);
+}
+
+function getSkuWiseAdSpendYearOption(file,label){
+  const fileName=String(file||'').trim();
+  const labelName=String(label||'').trim();
+  return SKU_WISE_AD_SPEND_YEARS.find(option=>option.file===fileName || option.label===labelName);
 }
 
 async function handleDatasetSelection(type,file,label,triggerEl){
@@ -2745,6 +2753,13 @@ async function handleDatasetSelection(type,file,label,triggerEl){
   if(datasetType==='yearPromptSkuAdSpend'){
     openSkuAdSpendYearModal(triggerEl);
     return;
+  }
+  const skuYearOption=getSkuWiseAdSpendYearOption(datasetFile,datasetLabel);
+  if(skuYearOption){
+    if(state.selectedYear===null || String(state.selectedYear)!==String(skuYearOption.year)){
+      openSkuAdSpendYearModal(triggerEl);
+      return;
+    }
   }
   try{
     showLoading(true);


### PR DESCRIPTION
### Motivation
- Fix a critical bug where clicking "SKU WISE AD SPEND" immediately loaded the 2025 dashboard and skipped the year selection UI by enforcing an explicit year prompt and blocking loads until a year is chosen.
- Ensure there is no implicit default/fallback year and dashboard rendering is only permitted after the user selects a year.

### Description
- Updated the SKU year modal header to `Select Year` while keeping the 2025/2026 options visible in the UI.
- Added a new `state.selectedYear` state and set it when the user picks a SKU year in `selectSkuAdSpendYear`.
- Added `getSkuWiseAdSpendYearOption` helper and a gate in `handleDatasetSelection` that detects SKU-wise options and opens the year modal (and returns) if `selectedYear` is `null` or does not match the requested year, preventing any dataset load until selection.
- Kept the explicit mapping `SKU_WISE_AD_SPEND_YEARS` (2025 → `SKU WISE AD SPEND 2025.xlsx`, 2026 → `SKU WISE AD SPEND 2026.xlsx`) and avoided adding any fallback/default loading behavior.

### Testing
- Performed source searches with `rg` to confirm the SKU year constants and that no hard-coded fallback loader strings remain, which succeeded.
- Launched a local static server using `python -m http.server 8000` and executed Playwright smoke scripts (with `sessionStorage` auth injection) to try to open the dataset menu and trigger the SKU year modal; the Playwright runs timed out or could not locate the `#datasetMenuBtn` locator so the end-to-end modal-open assertion could not be completed.
- Captured debug screenshots during the Playwright attempts for investigation; automated modal-open verification failed due to locator/timeouts and will need a brief follow-up environment check to validate the UI interaction end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69745e39e2888320a426c24ce433a961)